### PR TITLE
bug 820516 - JSONField doesn't serialize JSON

### DIFF
--- a/auslib/admin/views/forms.py
+++ b/auslib/admin/views/forms.py
@@ -33,6 +33,7 @@ class JSONFieldMixin(object):
             log.debug('No value list, setting self.data to default')
             self._set_default()
 
+
 # We need to be sure that we list JSONFieldMixin BEFORE the FileField in the derived classes list
 # We want to use JSONFieldMixin's version of process_formdata instead of FileField's version.
 class JSONBlobFileField(JSONFieldMixin, TextField):
@@ -54,6 +55,10 @@ class JSONTextField(JSONFieldMixin, TextField):
 
     def _set_default(self):
         self.data = {}
+
+    def _value(self):
+        return json.dumps(self.data) if self.data is not None else u''
+
 
 class NullableTextField(TextField):
     """TextField that parses incoming data converting empty strings to None's."""

--- a/auslib/test/admin/views/test_forms.py
+++ b/auslib/test/admin/views/test_forms.py
@@ -1,0 +1,32 @@
+import json
+import cgi
+import flask
+from auslib.test.admin.views.base import ViewTest
+from auslib.admin.views.forms import PermissionForm
+
+
+class TestFormsWithJSONFields(ViewTest):
+
+    def testRenderPermissionForm(self):
+        """Rendering the Permission form with a dict for the options field
+        should serialize it when preparing it as the input tag value in HTML"""
+        app = flask.Flask(__name__)
+        app.config['SECRET_KEY'] = 'abc123'
+        app.config['CSRF_ENABLED'] = False
+        with app.test_request_context('/'):
+            struct = {'foo': u'\xe3'}
+            form = PermissionForm(options=struct)
+            assert not form.is_submitted()
+            output = form.options()
+            expected = 'value="%s"' % cgi.escape(json.dumps(struct), True)
+            self.assertTrue(expected in output, expected)
+
+        struct = {'bar': u'\xe3'}
+        data = {
+            'options': json.dumps(struct),
+            'data_version': 1,
+        }
+        with app.test_request_context('/', method='POST', data=data):
+            app.preprocess_request()
+            form = PermissionForm()
+            self.assertEqual(form.options.data, struct)


### PR DESCRIPTION
@bhearsum r?

Now the user permissions form works. You can type it in with odd whitespace but it gets automatically cleaned up because the inputted JSON string gets converted to a real dict and back out again as a serialized string. 
