### PR TITLE
Bug 1495714 - Compare data_version with integer_types(int, long)

### DIFF
--- a/auslib/db.py
+++ b/auslib/db.py
@@ -8,7 +8,7 @@ import simplejson as json
 import sys
 import time
 
-from six import iteritems, string_types, reraise, text_type
+from six import integer_types, iteritems, string_types, reraise, text_type
 
 from sqlalchemy import Table, Column, Integer, Text, String, MetaData, \
     create_engine, select, BigInteger, Boolean, join, func
@@ -1883,7 +1883,7 @@ class Releases(AUSTable):
                 raise KeyError("Couldn't find release with name '%s'" % name)
 
         def get_data_version(obj):
-            if isinstance(obj, int):
+            if isinstance(obj, integer_types):
                 return obj
             return obj["data_version"]
 


### PR DESCRIPTION
@nthomas-mozilla, I was not able to reproduce the Bug 1495714 with the development database. But I made some tests by scheduling a release change and try push "View Data" button in UI after change was enacted. 
Due to a wrong integer comparison, the system was not able to get the cached blob data version, causing the http 500 error in admin.

Can you try reproduce the https://bugzilla.mozilla.org/show_bug.cgi?id=1495714#c14 against this commit or attach the `Firefox-63.0.1-build4-No-WNP`  file to bug?

Edit:
Integer type check must be done using `six.integer_types` to be compatible between Py27 and Py3.