### PR TITLE
Bug 1433466 - Added better validation for memory field

### DIFF
--- a/auslib/test/admin/views/test_rules.py
+++ b/auslib/test/admin/views/test_rules.py
@@ -149,6 +149,13 @@ class TestRulesAPI_JSON(ViewTest):
         self.assertEqual(r[0]["memory"], "<7373")
         self.assertEqual(r[0]["data_version"], 1)
 
+    def testCreateRuleWithInvalidMemory(self):
+        for invalid in ("<", "=", "=12", "=>896", "=<896", "abc"):
+            ret = self._post(
+                "/rules", data=dict(backgroundRate=33, mapping="c", priority=0, memory=invalid, product="Firefox", update_type="minor", channel="nightly")
+            )
+        self.assertEqual(ret.status_code, 400, "does not match")
+
     def testCreateRuleWithMig64(self):
         ret = self._post("/rules", data=dict(backgroundRate=33, mapping="c", priority=0, mig64=True, product="Firefox", update_type="minor", channel="nightly"))
         rule_id = int(ret.get_data())

--- a/auslib/web/common/swagger/definitions.yml
+++ b/auslib/web/common/swagger/definitions.yml
@@ -338,6 +338,7 @@ definitions:
         format: ascii
         minLength: 0
         maxLength: 100
+        pattern: "(^[<>0-9][=]?[0-9]*\\d$)"
         example: '<8000'
 
       fallbackMapping:


### PR DESCRIPTION
Hi @bhearsum ,

I have added integer validation to the memory field but it doesn't support the '+' operator yet. Any suggestions on the best way to handle it?

