### PR TITLE
Generate .dockercfg instead of using 'docker login'

### DIFF
--- a/agent/scripts/push-dockerimage.sh
+++ b/agent/scripts/push-dockerimage.sh
@@ -7,14 +7,7 @@ tags=( $@ )
 password_url="taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/balrog:dockerhub"
 artifact_url="taskcluster/queue/v1/task/${TASK_ID}/runs/${RUN_ID}/artifacts/public/docker-image-shasum256.txt"
 artifact_expiry=$(date -d "+1 year" -u +%FT%TZ)
-dockerhub_email=release+balrog@mozilla.com
-dockerhub_username=mozillabalrog
-dockerhub_password=$(curl ${password_url} | python -c 'import json, sys; a = json.load(sys.stdin); print a["secret"]["dockerhub_password"]')
 
-if [ -z $dockerhub_password ]; then
-    echo "Dockerhub password not set, can't continue!"
-    exit 1
-fi
 if [ ${#tags[*]} -eq 0 ]; then
     echo "Must pass at least one tag"
     exit 2
@@ -34,8 +27,9 @@ EOF
 
 echo "Building Docker image"
 docker build -t buildtemp .
-echo "Logging into Dockerhub"
-docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
+# docker login stopped working in Taskcluster for some reason
+wget -qO- $password_url | jq '.secret.dockercfg' > /root/.dockercfg
+chmod 600 /root/.dockercfg
 
 for tag in ${tags[*]}; do
     echo "Tagging Docker image with ${tag}"

--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -10,14 +10,7 @@ tags=( $@ )
 password_url="taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/balrog:dockerhub"
 artifact_url="taskcluster/queue/v1/task/${TASK_ID}/runs/${RUN_ID}/artifacts/public/docker-image-shasum256.txt"
 artifact_expiry=$(date -d "+1 year" -u +%FT%TZ)
-dockerhub_email=release+balrog@mozilla.com
-dockerhub_username=mozillabalrog
-dockerhub_password=$(curl ${password_url} | python -c 'import json, sys; a = json.load(sys.stdin); print a["secret"]["dockerhub_password"]')
 
-if [ -z $dockerhub_password ]; then
-    echo "Dockerhub password not set, can't continue!"
-    exit 1
-fi
 if [ ${#tags[*]} -eq 0 ]; then
     echo "Must pass at least one tag"
     exit 2
@@ -37,8 +30,10 @@ EOF
 
 echo "Building Docker image"
 docker build -f $DOCKERFILE -t buildtemp .
-echo "Logging into Dockerhub"
-docker login -e $dockerhub_email -u $dockerhub_username -p $dockerhub_password
+echo "=== Generating dockercfg ==="
+# docker login stopped working in Taskcluster for some reason
+wget -qO- $password_url | jq '.secret.dockercfg' > /root/.dockercfg
+chmod 600 /root/.dockercfg
 
 for tag in ${tags[*]}; do
     echo "Tagging Docker image with ${tag}"


### PR DESCRIPTION
`docker login` stopped working recently, this is a workaround that has been used in other places (eg https://github.com/mozilla-releng/shipit/pull/114)