### PR TITLE
Do not try to match memory if not passed

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -91,7 +91,7 @@ tasks:
                   git clone ${repo_url} balrog &&
                   cd balrog &&
                   git checkout ${head_sha} &&
-                  pip install coveralls tox &&
+                  pip install coveralls==1.9.2 tox &&
                   tox &&
                   coveralls
               features:

--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -1645,7 +1645,7 @@ class Rules(AUSTable):
             if not matchBuildID(rule["buildID"], updateQuery.get("buildID", "")):
                 self.log.debug("%s doesn't match %s", rule["buildID"], updateQuery["buildID"])
                 continue
-            if not matchMemory(rule["memory"], updateQuery.get("memory", "")):
+            if not matchMemory(rule["memory"], updateQuery.get("memory")):
                 self.log.debug("%s doesn't match %s", rule["memory"], updateQuery.get("memory"))
                 continue
             # To help keep the rules table compact, multiple OS versions may be

--- a/src/auslib/util/rulematching.py
+++ b/src/auslib/util/rulematching.py
@@ -127,9 +127,13 @@ def matchBuildID(ruleBuildID, queryBuildID):
 def matchMemory(ruleMemory, queryMemory):
     """Decides whether a memory value from the rules matches an incoming one.
        If the ruleMemory is null, we match any queryMemory. If it's not
-       null, we must either match exactly, or match with a camparison
+       null, we must either match exactly, or match with a comparison
        operator."""
-    if ruleMemory is None:
+    if ruleMemory is None or queryMemory is None:
+        return True
+    try:
+        queryMemory = int(queryMemory)
+    except (TypeError, ValueError):
         return True
     return int_compare(queryMemory, ruleMemory)
 

--- a/tests/util/test_rulematching.py
+++ b/tests/util/test_rulematching.py
@@ -1,0 +1,26 @@
+import unittest
+
+from auslib.util.rulematching import matchMemory
+
+
+class TestMatchMemory(unittest.TestCase):
+    def test_empty_string(self):
+        self.assertTrue(matchMemory(">2048", ""))
+
+    def test_none(self):
+        self.assertTrue(matchMemory(">2048", None))
+
+    def test_int(self):
+        self.assertTrue(matchMemory(">2048", 10000))
+
+    def test_parsable_string(self):
+        self.assertTrue(matchMemory(">2048", "10000"))
+
+    def test_unparsable_string(self):
+        self.assertTrue(matchMemory(">2048", "trash"))
+
+    def test_int_false(self):
+        self.assertFalse(matchMemory(">2048", 10))
+
+    def test_parsable_string_false(self):
+        self.assertFalse(matchMemory(">2048", "10"))


### PR DESCRIPTION
I found this issue in Sentry (more than 16k occurrences). Queries like [this
one](https://aus5.mozilla.org/update/3/Firefox/56.0/20170926190823/WINNT_x86-msvc-x64/en-GB/release/Windows_NT%206.1.1.0%20%28x64%29%28noBug1296630v1%29%28nowebsense%29/default/default/update.xml?mig64=1)
render
`'&gt;' not supported between instances of 'str' and 'int'`
so the user don't get updates.

The query doesn't contain memory information, so it's set to an empty
string. `int_compare()` barfs when the first argument is an empty
string.