### PR TITLE
Fix issues with bad data being passed in systemCapabilities field

### DIFF
--- a/src/auslib/web/public/client.py
+++ b/src/auslib/web/public/client.py
@@ -36,11 +36,18 @@ def getSystemCapabilities(systemCapabilities):
     # New-style SYSTEM_CAPABILITIES, as implemented in https://bugzilla.mozilla.org/show_bug.cgi?id=1373367
     if systemCapabilities.startswith("ISET:"):
         for part in systemCapabilities.split(","):
+            # Skip fields with an unparseable format, which we see often. Eg:
+            # ISET:SSE4_2,MEM:32768,(select*from(select(sleep(20)))a)
+            if ":" not in part:
+                continue
             key, value = part.split(":", 1)
             if key == "ISET":
                 caps["instructionSet"] = value
             elif key == "MEM":
-                caps["memory"] = int(value)
+                try:
+                    caps["memory"] = int(value)
+                except ValueError:
+                    caps["memory"] = None
             elif key == "JAWS":
                 caps["jaws"] = bool(int(value))
     # Old-style, unprefixed SYSTEM_CAPABILITIES. Only supports instructionSet and memory.
@@ -53,7 +60,10 @@ def getSystemCapabilities(systemCapabilities):
             caps["instructionSet"] = parts[0]
         elif len(parts) == 2:
             caps["instructionSet"] = parts[0]
-            caps["memory"] = int(parts[1])
+            try:
+                caps["memory"] = int(parts[1])
+            except ValueError:
+                caps["memory"] = None
 
     return caps
 

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -40,10 +40,22 @@ class TestGetSystemCapabilities(unittest.TestCase):
         self.assertEqual(client_api.getSystemCapabilities("NA"), {"instructionSet": "NA", "memory": None, "jaws": None})
 
     def testNonIntegerMemory(self):
-        self.assertRaises(ValueError, client_api.getSystemCapabilities, ("ISET:SSE2,MEM:63T1A"))
+        # Real things we've seen for "memory"
+        self.assertEqual(
+            client_api.getSystemCapabilities("ISET:SSE2,MEM:16384');declare @q varchar(99);set @q='"), {"instructionSet": "SSE2", "memory": None, "jaws": None}
+        )
+        self.assertEqual(client_api.getSystemCapabilities("ISET:SSE2,MEM:-nan(ind)"), {"instructionSet": "SSE2", "memory": None, "jaws": None})
+        self.assertEqual(client_api.getSystemCapabilities("ISET:SSE2,MEM:8.1023"), {"instructionSet": "SSE2", "memory": None, "jaws": None})
+        self.assertEqual(client_api.getSystemCapabilities("ISET:SSE2,MEM:unknown"), {"instructionSet": "SSE2", "memory": None, "jaws": None})
 
     def testUnknownField(self):
         self.assertEqual(client_api.getSystemCapabilities("ISET:SSE3,MEM:6721,PROC:Intel"), {"instructionSet": "SSE3", "memory": 6721, "jaws": None})
+
+    def testBadFieldFormat(self):
+        self.assertEqual(
+            client_api.getSystemCapabilities("ISET:SSE4_2,MEM:32768,(select*from(select(sleep(20)))a)"),
+            {"instructionSet": "SSE4_2", "memory": 32768, "jaws": None},
+        )
 
 
 @pytest.mark.usefixtures("current_db_schema")


### PR DESCRIPTION
This should fix https://sentry.prod.mozaws.net/operations/prod-public/issues/6445338/?query=is:unresolved, https://sentry.prod.mozaws.net/operations/prod-public/issues/6440645/?query=is:unresolved, and https://sentry.prod.mozaws.net/operations/prod-public/issues/6445339/?query=is:unresolved -- all of which are around unexpected data being sent in `systemCapabilities`.