### PR TITLE
Sort array instead of suggestions instead of the string we pass to get the suggestions for permission actions

### DIFF
--- a/ui/src/views/Users/ViewUser/index.jsx
+++ b/ui/src/views/Users/ViewUser/index.jsx
@@ -427,7 +427,7 @@ function ViewUser({ isNewUser, ...props }) {
           onValueChange={handleRestrictionTextChange(permission, 'actionText')}
           value={permission.metadata.actionText}
           getSuggestions={getSuggestions(
-            getSupportedActions(permission.name.sort())
+            getSupportedActions(permission.name).sort()
           )}
           label="Action Restrictions"
         />


### PR DESCRIPTION
This is currently breaking `ViewUser`. It's fallout from https://github.com/mozilla-releng/balrog-ui/pull/239