### PR TITLE
Allow longer lines before eliding

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="balrogclient",
-    version="1.1.0",
+    version="1.1.1",
     description="Balrog Admin API Client",
     author="Mozilla Release Engineers",
     author_email="release+python@mozilla.com",

--- a/client/src/balrogclient/api.py
+++ b/client/src/balrogclient/api.py
@@ -9,6 +9,7 @@ import time
 import requests
 import requests.auth
 
+MAX_LOG_LINE_LENGTH = 10000
 # Refresh the tokens 5 minutes before they expire
 REFRESH_THRESHOLD = 5 * 60
 _token_cache = {}
@@ -16,8 +17,9 @@ _token_cache = {}
 
 def _json_log_data(data):
     log = json.dumps(data)
-    if len(log) > 10000:
-        log = log[:9980] + "<...{} characters elided ...>".format(len(log) - 9980)
+    if len(log) > MAX_LOG_LINE_LENGTH:
+        slice_length = MAX_LOG_LINE_LENGTH - 20
+        log = log[:slice_length] + "<...{} characters elided ...>".format(len(log) - slice_length)
     return log
 
 

--- a/client/src/balrogclient/api.py
+++ b/client/src/balrogclient/api.py
@@ -16,8 +16,8 @@ _token_cache = {}
 
 def _json_log_data(data):
     log = json.dumps(data)
-    if len(log) > 100:
-        log = log[:80] + "<...{} characters elided ...>".format(len(log) - 80)
+    if len(log) > 10000:
+        log = log[:9980] + "<...{} characters elided ...>".format(len(log) - 9980)
     return log
 
 

--- a/client/tests/test_balrog_api.py
+++ b/client/tests/test_balrog_api.py
@@ -26,7 +26,7 @@ def test_log_lines_truncated(caplog):
     caplog.set_level(logging.DEBUG)
 
     api = API(AUTH0_SECRETS, session=session)
-    api.do_request("https://api/", {"data": "a" * 100}, "GET")
+    api.do_request("https://api/", {"data": "a" * 11000}, "GET")
 
     logs = [message.split(": ", 1)[1] for message in caplog.messages if message.startswith("Data sent: ")]
-    assert logs == ['{"data": "' + "a" * 70 + "<...32 characters elided ...>"]
+    assert logs == ['{"data": "' + "a" * 9970 + "<...1032 characters elided ...>"]


### PR DESCRIPTION
The current eliding that happens as part of Balrog submission ends up not showing any useful parts of the request, which makes debugging submission issues next to impossible.

This patch should elide long enough to show the entire body of regular requests, while still eliding enough to avoid https://github.com/mozilla-releng/scriptworker/issues/362.