### PR TITLE
Schedule changes slightly further into the future by default

### DIFF
--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -285,7 +285,7 @@ function ListReleases(props) {
   const scheduleReadWriteChange = async release => {
     const sc = {
       change_type: 'update',
-      when: new Date().getTime() + 5000,
+      when: new Date().getTime() + 30000,
       name: release.name,
       product: release.product,
       read_only: false,

--- a/ui/src/views/Releases/Release/index.jsx
+++ b/ui/src/views/Releases/Release/index.jsx
@@ -171,7 +171,7 @@ function Release(props) {
     // which means that changes that don't require signoff will happen
     // almost immediately, and changes that do require signoff will wait
     // until those are completed.
-    const when = new Date().getTime() + 5000;
+    const when = new Date().getTime() + 30000;
     let error = null;
 
     if (scId) {

--- a/ui/src/views/RequiredSignoffs/utils/updateRequiredSignoffs.js
+++ b/ui/src/views/RequiredSignoffs/utils/updateRequiredSignoffs.js
@@ -73,7 +73,7 @@ export default params => {
           data_version: role.data_version,
           useScheduledChange: true,
           change_type: 'update',
-          when: new Date().getTime() + 5000,
+          when: new Date().getTime() + 30000,
           scId: role.sc ? role.sc.sc_id : null,
           ...extraData,
         });
@@ -86,7 +86,7 @@ export default params => {
           role: role.name,
           signoffs_required: role.signoffs_required,
           change_type: 'insert',
-          when: new Date().getTime() + 5000,
+          when: new Date().getTime() + 30000,
         });
 
         useScheduledChange = true;
@@ -110,7 +110,7 @@ export default params => {
           data_version: role.data_version,
           useScheduledChange: true,
           change_type: 'delete',
-          when: new Date().getTime() + 5000,
+          when: new Date().getTime() + 30000,
         });
       })
     )

--- a/ui/src/views/Rules/ListRuleRevisions/index.jsx
+++ b/ui/src/views/Rules/ListRuleRevisions/index.jsx
@@ -111,7 +111,7 @@ function ListRuleRevisions(props) {
     delete ruleData.data_version;
     const { error, data } = await addSC({
       change_type: 'update',
-      when: new Date().getTime() + 5000,
+      when: new Date().getTime() + 30000,
       data_version: revisions[0].data_version,
       ...ruleData,
     });

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -545,7 +545,7 @@ function ListRules(props) {
     const when =
       scheduleDeleteDate >= now
         ? scheduleDeleteDate.getTime()
-        : now.getTime() + 5000;
+        : now.getTime() + 30000;
     let error = null;
     let ret = null;
 
@@ -751,7 +751,7 @@ function ListRules(props) {
 
     if (filteredProductChannelRequiresSignoff) {
       const now = new Date();
-      const when = now.getTime() + 5000;
+      const when = now.getTime() + 30000;
       const { error } = await scheduleEnableUpdates(
         product,
         channel,

--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -188,7 +188,7 @@ function Rule({ isNewRule, user, ...props }) {
   const handleCreateRule = async () => {
     const now = new Date();
     const when =
-      scheduleDate >= now ? scheduleDate.getTime() : now.getTime() + 5000;
+      scheduleDate >= now ? scheduleDate.getTime() : now.getTime() + 30000;
     const data = {
       alias: rule.alias,
       backgroundRate: rule.backgroundRate,
@@ -226,7 +226,7 @@ function Rule({ isNewRule, user, ...props }) {
   const handleUpdateRule = async () => {
     const now = new Date();
     const when =
-      scheduleDate >= now ? scheduleDate.getTime() : now.getTime() + 5000;
+      scheduleDate >= now ? scheduleDate.getTime() : now.getTime() + 30000;
     const data = {
       alias: rule.alias,
       backgroundRate: rule.backgroundRate,

--- a/ui/src/views/Users/utils/updateUser.js
+++ b/ui/src/views/Users/utils/updateUser.js
@@ -89,7 +89,7 @@ export default params => {
             dataVersion: permission.data_version,
             scId: permission.sc.sc_id,
             scDataVersion: permission.sc.sc_data_version,
-            when: new Date().getTime() + 5000,
+            when: new Date().getTime() + 30000,
           });
         }
 
@@ -99,7 +99,7 @@ export default params => {
           options,
           dataVersion: permission.data_version,
           changeType: 'update',
-          when: new Date().getTime() + 5000,
+          when: new Date().getTime() + 30000,
         });
       }),
       additionalPermissions.map(permission => {
@@ -118,7 +118,7 @@ export default params => {
           permission: permission.name,
           options,
           changeType: 'insert',
-          when: new Date().getTime() + 5000,
+          when: new Date().getTime() + 30000,
         });
       }),
       removedPermissions.map(permission => {
@@ -134,7 +134,7 @@ export default params => {
           permission: permission.name,
           dataVersion: permission.data_version,
           changeType: 'delete',
-          when: new Date().getTime() + 5000,
+          when: new Date().getTime() + 30000,
         });
       })
     )


### PR DESCRIPTION
@srfraser hit an issue today where he got an error trying to update a Release. This turned out to be because it was a large Release which took awhile to upload, and the 5 seconds in the future we schedule ended up being in the past when the backend processed it.

To help avoid this, and similar failures due to clock skew, let's bump up the default in-the-future time to 30s.