### PR TITLE
Add tables for split Releases

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,7 +65,8 @@ google-auth==1.11.2 \
     --hash=sha256:28a848d47c55075a0f29d7e26b7a213515c137ab8f0670e546e46d1277060e47
 google-cloud-core==1.3.0 \
     --hash=sha256:6ae5c62931e8345692241ac1939b85a10d6c38dc9e2854bdbacb7e5ac3033229 \
-    --hash=sha256:878f9ad080a40cdcec85b92242c4b5819eeb8f120ebc5c9f640935e24fc129d8    # via google-cloud-storage
+    --hash=sha256:878f9ad080a40cdcec85b92242c4b5819eeb8f120ebc5c9f640935e24fc129d8 \
+    # via google-cloud-storage
 google-cloud-storage==1.26.0 \
     --hash=sha256:22f25d1c627b9b688b8873ea48203f337dd5448a242089e688d99c2fa46a8b89 \
     --hash=sha256:ffdfaeb319c47deaf5b25c6bf1f1f52a183ba6abb0bb80586509a9b68dc35d31
@@ -74,23 +75,27 @@ google-resumable-media==0.5.0 \
     --hash=sha256:b86140d5a0b6d290084b11bde90ee9aecad357ba0e0d67388d016b8340320927 \
     # via google-cloud-storage
 googleapis-common-protos==1.51.0 \
-    --hash=sha256:013c91704279119150e44ef770086fdbba158c1f978a6402167d47d5409e226e    # via google-api-core
+    --hash=sha256:013c91704279119150e44ef770086fdbba158c1f978a6402167d47d5409e226e \
+    # via google-api-core
 idna==2.9 \
     --hash=sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb \
-    --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa    # via requests
+    --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa \
+    # via requests
 importlib-metadata==1.5.0 \
     --hash=sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302 \
-    --hash=sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b    # via jsonschema
+    --hash=sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b \
+    # via jsonschema
 inflection==0.3.1 \
     --hash=sha256:18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca \
     # via connexion
 itsdangerous==1.1.0 \
     --hash=sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19 \
     --hash=sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749 \
-    # via flask
+    # via flask, flask-wtf
 jinja2==2.11.1 \
     --hash=sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250 \
-    --hash=sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49    # via flask
+    --hash=sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49 \
+    # via flask
 jsonschema==3.2.0 \
     --hash=sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163 \
     --hash=sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
@@ -99,13 +104,16 @@ markupsafe==1.1.1 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
     --hash=sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235 \
     --hash=sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5 \
+    --hash=sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42 \
     --hash=sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff \
     --hash=sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b \
     --hash=sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1 \
     --hash=sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e \
     --hash=sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183 \
     --hash=sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66 \
+    --hash=sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b \
     --hash=sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1 \
+    --hash=sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15 \
     --hash=sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1 \
     --hash=sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e \
     --hash=sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b \
@@ -122,15 +130,14 @@ markupsafe==1.1.1 \
     --hash=sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6 \
     --hash=sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f \
     --hash=sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f \
+    --hash=sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2 \
     --hash=sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7 \
+    --hash=sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be \
     # via jinja2
 mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723 \
     # via requests-hawk
-more-itertools==8.2.0 \
-    --hash=sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c \
-    --hash=sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507    # via zipp
 mysqlclient==1.4.6 \
     --hash=sha256:4c82187dd6ab3607150fbb1fa5ef4643118f3da122b8ba31c3149ddd9cf0cb39 \
     --hash=sha256:9e6080a7aee4cc6a06b58b59239f20f1d259c1d2fddf68ddeed242d2311c7087 \
@@ -148,7 +155,6 @@ pbr==5.4.4 \
 protobuf==3.11.3 \
     --hash=sha256:0bae429443cc4748be2aadfdaf9633297cfaeb24a9a02d0ab15849175ce90fab \
     --hash=sha256:24e3b6ad259544d717902777b33966a1a069208c885576254c112663e6a5bb0f \
-    --hash=sha256:2affcaba328c4662f3bc3c0e9576ea107906b2c2b6422344cdad961734ff6b93 \
     --hash=sha256:310a7aca6e7f257510d0c750364774034272538d51796ca31d42c3925d12a52a \
     --hash=sha256:52e586072612c1eec18e1174f8e3bb19d08f075fc2e3f91d3b16c919078469d0 \
     --hash=sha256:73152776dc75f335c476d11d52ec6f0f6925774802cd48d6189f4d5d7fe753f4 \
@@ -164,7 +170,8 @@ protobuf==3.11.3 \
     --hash=sha256:e512b7f3a4dd780f59f1bf22c302740e27b10b5c97e858a6061772668cd6f961 \
     --hash=sha256:ef2c2e56aaf9ee914d3dccc3408d42661aaf7d9bb78eaa8f17b2e6282f214481 \
     --hash=sha256:fac513a9dc2a74b99abd2e17109b53945e364649ca03d9f7a0b96aa8d1807d0a \
-    --hash=sha256:fdfb6ad138dbbf92b5dbea3576d7c8ba7463173f7d2cb0ca1bd336ec88ddbd80    # via google-api-core, googleapis-common-protos
+    --hash=sha256:fdfb6ad138dbbf92b5dbea3576d7c8ba7463173f7d2cb0ca1bd336ec88ddbd80 \
+    # via google-api-core, googleapis-common-protos
 pyasn1-modules==0.2.8 \
     --hash=sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e \
     --hash=sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74 \
@@ -203,9 +210,9 @@ pyyaml==5.3 \
 repoze.lru==0.7 \
     --hash=sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \
     --hash=sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea
-requests-hawk==1.0.0 \
-    --hash=sha256:aef0dff8053dcae2057774516386bed0a3bc03fabea9e18f3aa98f02672ea5d0 \
-    --hash=sha256:c2626ab31ebef0c81b97781c44c2275bfcc6d8e8520fc4ced495f0f386f8fe26
+requests-hawk==1.0.1 \
+    --hash=sha256:349ff5939fc80747f5fdedd249d5038f156a5404533ac3eaa4d8649f90508fe1 \
+    --hash=sha256:f85355c97304c6f5f7d51cdc2dcff08d7d8b64cf99ee75e878384cd038ad686d
 requests==2.23.0 \
     --hash=sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee \
     --hash=sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6
@@ -213,12 +220,13 @@ rsa==4.0 \
     --hash=sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66 \
     --hash=sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487 \
     # via google-auth, python-jose
-sentry-sdk[flask]==0.14.1 \
-    --hash=sha256:b06dd27391fd11fb32f84fe054e6a64736c469514a718a99fb5ce1dff95d6b28 \
-    --hash=sha256:e023da07cfbead3868e1e2ba994160517885a32dfd994fc455b118e37989479b
+sentry-sdk[flask]==0.14.2 \
+    --hash=sha256:480eee754e60bcae983787a9a13bc8f155a111aef199afaa4f289d6a76aa622a \
+    --hash=sha256:a920387dc3ee252a66679d0afecd34479fb6fc52c2bc20763793ed69e5b0dcc0
 six==1.14.0 \
     --hash=sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a \
-    --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c    # via ecdsa, google-api-core, google-auth, google-resumable-media, jsonschema, mohawk, openapi-spec-validator, protobuf, pyrsistent, python-dateutil, python-jose, sqlalchemy-migrate, swagger-spec-validator
+    --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c \
+    # via ecdsa, google-api-core, google-auth, google-resumable-media, jsonschema, mohawk, openapi-spec-validator, protobuf, pyrsistent, python-dateutil, python-jose, sqlalchemy-migrate, swagger-spec-validator
 spec-synthase==0.1.11 \
     --hash=sha256:62396a95541cec2f792fe4f1f10e610e3dbdcdee843ee8f65dc243e8bb387c86 \
     --hash=sha256:9507c2f83a1c0a6fb7e18c0fa4eb9cc7a3d874e964b7c55dd2b531e5c70598bf
@@ -231,28 +239,32 @@ sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873 \
     # via sqlalchemy-migrate
-swagger-spec-validator==2.4.3 \
-    --hash=sha256:57e29feb3aa921a9fb98bd70af148746b27c77d3207266f5571cebcce211e685 \
-    --hash=sha256:62ef22eca3f429d93fddda5d793d2a1a9057d3732e7a14606e641805326ae4a6
+swagger-spec-validator==2.5.0 \
+    --hash=sha256:61f2d2a732b886cf33c2c24886565be9692e5814cacc17fd973e095b72b33e4f \
+    --hash=sha256:8eb82682871f8d63067b455e2e055c8dd953ca260e791635b58dfe0b73ba1f43
 tempita==0.5.2 \
     --hash=sha256:cacecf0baa674d356641f1d406b8bff1d756d739c46b869a54de515d08e6fc9c \
     # via sqlalchemy-migrate
 urllib3==1.25.8 \
     --hash=sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc \
-    --hash=sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc    # via requests, sentry-sdk
+    --hash=sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc \
+    # via requests, sentry-sdk
 uwsgi==2.0.18 \
     --hash=sha256:4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583
 werkzeug==1.0.0 \
     --hash=sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096 \
-    --hash=sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16    # via flask
+    --hash=sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16 \
+    # via flask
 wtforms==2.2.1 \
     --hash=sha256:0cdbac3e7f6878086c334aa25dc5a33869a3954e9d1e015130d65a69309b3b61 \
     --hash=sha256:e3ee092c827582c50877cdbd49e9ce6d2c5c1f6561f849b3b068c1b8029626f1 \
     # via flask-wtf
 zipp==3.0.0 \
     --hash=sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2 \
-    --hash=sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a    # via importlib-metadata
+    --hash=sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a \
+    # via importlib-metadata
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==45.2.0 \
+    --hash=sha256:316484eebff54cc18f322dea09ed031b7e3eb00811b19dcedb09bc09bba7d93d \
+    --hash=sha256:89c6e6011ec2f6d57d43a3f9296c4ef022c2cbf49bab26b407fe67992ae3397f

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -16,14 +16,16 @@ babel==2.8.0 \
     # via sphinx
 docutils==0.16 \
     --hash=sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af \
-    --hash=sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc    # via sphinx
+    --hash=sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc \
+    # via sphinx
 imagesize==1.2.0 \
     --hash=sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1 \
     --hash=sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1 \
     # via sphinx
 packaging==20.1 \
     --hash=sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73 \
-    --hash=sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334    # via sphinx
+    --hash=sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334 \
+    # via sphinx
 pygments==2.5.2 \
     --hash=sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b \
     --hash=sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe \
@@ -52,7 +54,8 @@ sphinxcontrib-devhelp==1.0.1 \
     # via sphinx
 sphinxcontrib-htmlhelp==1.0.3 \
     --hash=sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f \
-    --hash=sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b    # via sphinx
+    --hash=sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b \
+    # via sphinx
 sphinxcontrib-jsmath==1.0.1 \
     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178 \
     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8 \
@@ -66,6 +69,4 @@ sphinxcontrib-serializinghtml==1.1.3 \
     --hash=sha256:db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768 \
     # via sphinx
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,17 +6,19 @@
 #    pip-compile-multi
 #
 -r test.txt
+distlib==0.3.0 \
+    --hash=sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21 \
+    # via virtualenv
 filelock==3.0.12 \
     --hash=sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59 \
     --hash=sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836 \
-    # via tox
+    # via tox, virtualenv
 tox==3.14.5 \
     --hash=sha256:0cbe98369081fa16bd6f1163d3d0b2a62afa29d402ccfad2bd09fb2668be0956 \
     --hash=sha256:676f1e3e7de245ad870f956436b84ea226210587d1f72c8dfb8cd5ac7b6f0e70
-virtualenv==20.0.5 \
-    --hash=sha256:531b142e300d405bb9faedad4adbeb82b4098b918e35209af2adef3129274aae \
-    --hash=sha256:5dd42a9f56307542bddc446cfd10ef6576f11910366a07609fe8d0d88fa8fb7e    # via tox
+virtualenv==20.0.7 \
+    --hash=sha256:30ea90b21dabd11da5f509710ad3be2ae47d40ccbc717dfdd2efe4367c10f598 \
+    --hash=sha256:4a36a96d785428278edd389d9c36d763c5755844beb7509279194647b1ef47f1 \
+    # via tox
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,9 +17,9 @@ appdirs==1.4.3 \
 black==19.10b0 \
     --hash=sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b \
     --hash=sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539
-check-manifest==0.40 \
-    --hash=sha256:42de6eaab4ed149e60c9b367ada54f01a3b1e4d6846784f9b9710e770ff5572c \
-    --hash=sha256:78dd077f2c70dbac7cfcc9d12cbd423914e787ea4b5631de45aecd25b524e8e3
+check-manifest==0.41 \
+    --hash=sha256:4046b1260e63c139be6441fe8db8d9221f495ff39b81add2a55e5ca35dde7a6a \
+    --hash=sha256:88afe85b751717688f8bc3b63d9543d0d962da98f1f420c554eaeb8d76c571a8
 coverage==5.0.3 \
     --hash=sha256:15cf13a6896048d6d947bf7d222f36e4809ab926894beb748fc9caa14605d9c3 \
     --hash=sha256:1daa3eceed220f9fdb80d5ff950dd95112cd27f70d004c7918ca6dfc6c47054c \
@@ -84,19 +84,29 @@ mccabe==0.6.1 \
 mock==4.0.1 \
     --hash=sha256:2a572b715f09dd2f0a583d8aeb5bb67d7ed7a8fd31d193cf1227a99c16a67bc3 \
     --hash=sha256:5e48d216809f6f393987ed56920305d8f3c647e6ed35407c1ff2ecb88a9e1151
+more-itertools==8.2.0 \
+    --hash=sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c \
+    --hash=sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507 \
+    # via pytest
 packaging==20.1 \
     --hash=sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73 \
-    --hash=sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334    # via pytest
+    --hash=sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334 \
+    # via pytest
 pathspec==0.7.0 \
     --hash=sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424 \
     --hash=sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96 \
     # via black
+pep517==0.8.1 \
+    --hash=sha256:5ce351f3be71d01bb094d63253854b6139931fcaba8e2f380c02102136c51e40 \
+    --hash=sha256:882e2eeeffe39ccd6be6122d98300df18d80950cb5f449766d64149c94c5614a \
+    # via check-manifest
 pip-compile-multi==1.5.8 \
     --hash=sha256:6c77a2cdae62c28d6c151111e6a38ca9935ef37898f9766100ec2064326d74e9 \
     --hash=sha256:fd92e064e8b187ce919a9b1e22bc7ff41e630bbfba8a9ab0501c260a2580feda
 pip-tools==4.5.0 \
     --hash=sha256:144fbd764e88f761246f832370721dccabfefbbc4ce3aa8468f6802ac6519217 \
-    --hash=sha256:61455cfdaa183930eefd8259f393812d94005fb9f8249edb640ed1b66f678116    # via pip-compile-multi
+    --hash=sha256:61455cfdaa183930eefd8259f393812d94005fb9f8249edb640ed1b66f678116 \
+    # via pip-compile-multi
 pluggy==0.13.1 \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
     --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d \
@@ -151,7 +161,8 @@ regex==2020.2.20 \
     --hash=sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e \
     --hash=sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70 \
     --hash=sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc \
-    --hash=sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0    # via black
+    --hash=sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0 \
+    # via black
 sortedcontainers==2.1.0 \
     --hash=sha256:974e9a32f56b17c1bac2aebd9dcf197f3eb9cd30553c5852a3187ad162e1a03a \
     --hash=sha256:d9e96492dd51fae31e60837736b38fe42a187b5404c16606ff7ee7cd582d4c60 \
@@ -159,7 +170,7 @@ sortedcontainers==2.1.0 \
 toml==0.10.0 \
     --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
     --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
-    # via black, check-manifest
+    # via black, check-manifest, pep517
 toposort==1.5 \
     --hash=sha256:d80128b83b411d503b0cdb4a8f172998bc1d3b434b6402a349b8ebd734d51a80 \
     --hash=sha256:dba5ae845296e3bf37b042c640870ffebcdeb8cd4df45adaa01d8c5476c557dd \
@@ -185,12 +196,11 @@ typed-ast==1.4.1 \
     --hash=sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34 \
     --hash=sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe \
     --hash=sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4 \
-    --hash=sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7    # via black
+    --hash=sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7 \
+    # via black
 wcwidth==0.1.8 \
     --hash=sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603 \
     --hash=sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8 \
     # via pytest
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools
+# The following packages are considered to be unsafe in a requirements file:

--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -2200,12 +2200,22 @@ class ReleasesJSON(AUSTable):
 
 
 class ReleaseAssets(AUSTable):
-    def __init__(self, db, metadata, dialect):
+    def __init__(self, db, metadata, dialect, history_buckets, historyClass):
         self.table = Table(
             "release_assets", metadata, Column("name", String(100), primary_key=True), Column("path", String(200), primary_key=True), Column("data", JSON),
         )
+        historyKwargs = {}
+        if history_buckets:
+            historyKwargs["buckets"] = history_buckets
+            historyKwargs["identifier_columns"] = ["name", "path"]
+            historyKwargs["data_column"] = "data"
+        else:
+            # Can't have history without a bucket
+            historyClass = None
 
-        super(ReleaseAssets, self).__init__(db, dialect, scheduled_changes=True, scheduled_changes_kwargs={"conditions": ["time"]})
+        super(ReleaseAssets, self).__init__(
+            db, dialect, scheduled_changes=True, scheduled_changes_kwargs={"conditions": ["time"]}, historyClass=historyClass, historyKwargs=historyKwargs
+        )
 
 
 class UserRoles(AUSTable):
@@ -2686,7 +2696,7 @@ class AUSDatabase(object):
         self.rulesTable = Rules(self, self.metadata, dialect)
         self.releasesTable = Releases(self, self.metadata, dialect, releases_history_buckets, releases_history_class)
         self.releasesJSONTable = ReleasesJSON(self, self.metadata, dialect, releases_history_buckets, releases_history_class)
-        self.releaseAssetsTable = ReleaseAssets(self, self.metadata, dialect)
+        self.releaseAssetsTable = ReleaseAssets(self, self.metadata, dialect, releases_history_buckets, releases_history_class)
         self.permissionsTable = Permissions(self, self.metadata, dialect)
         self.dockerflowTable = Dockerflow(self, self.metadata, dialect)
         self.productRequiredSignoffsTable = ProductRequiredSignoffsTable(self, self.metadata, dialect)

--- a/src/auslib/migrate/versions/034_add_release_details.py
+++ b/src/auslib/migrate/versions/034_add_release_details.py
@@ -1,0 +1,189 @@
+from sqlalchemy import JSON, BigInteger, Boolean, Column, Integer, MetaData, String, Table
+
+
+def upgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+    if migrate_engine.name == "mysql":
+        bigintType = BigInteger
+    elif migrate_engine.name == "sqlite":
+        bigintType = Integer
+
+    releases_json = Table(  # noqa
+        "releases_json",
+        metadata,
+        Column("name", String(100), primary_key=True),
+        Column("product", String(15), nullable=False),
+        Column("read_only", Boolean, default=False),
+        Column("data", JSON),
+        Column("data_version", Integer, nullable=False),
+    )
+
+    releases_json_scheduled_changes = Table(  # noqa
+        "releases_json_scheduled_changes",
+        metadata,
+        Column("sc_id", Integer, primary_key=True, autoincrement=True),
+        Column("scheduled_by", String(100), nullable=False),
+        Column("complete", Boolean, default=False),
+        Column("change_type", String(50), nullable=False),
+        Column("data_version", Integer, nullable=False),
+        Column("base_name", String(100), nullable=False),
+        Column("base_product", String(15)),
+        Column("base_data", JSON),
+        Column("base_read_only", Boolean, default=False),
+        Column("base_data_version", Integer),
+    )
+
+    releases_json_scheduled_changes_history = Table(  # noqa
+        "releases_json_scheduled_changes_history",
+        metadata,
+        Column("change_id", Integer, primary_key=True, autoincrement=True),
+        Column("changed_by", String(100), nullable=False),
+        Column("timestamp", bigintType, nullable=False),
+        Column("sc_id", Integer, nullable=False),
+        Column("scheduled_by", String(100)),
+        Column("complete", Boolean, default=False),
+        Column("change_type", String(50), nullable=True),
+        Column("data_version", Integer),
+        Column("base_name", String(100)),
+        Column("base_product", String(15)),
+        Column("base_data", JSON),
+        Column("base_read_only", Boolean, default=False),
+        Column("base_data_version", Integer),
+    )
+
+    releases_json_scheduled_changes_conditions = Table(  # noqa
+        "releases_json_scheduled_changes_conditions",
+        metadata,
+        Column("sc_id", Integer, primary_key=True, autoincrement=True),
+        Column("when", bigintType),
+        Column("data_version", Integer, nullable=False),
+    )
+
+    releases_json_scheduled_changes_conditions_history = Table(  # noqa
+        "releases_json_scheduled_changes_conditions_history",
+        metadata,
+        Column("change_id", Integer, primary_key=True, autoincrement=True),
+        Column("changed_by", String(100), nullable=False),
+        Column("timestamp", bigintType, nullable=False),
+        Column("sc_id", Integer, nullable=False),
+        Column("when", bigintType),
+        Column("data_version", Integer),
+    )
+
+    releases_json_scheduled_changes_signoffs = Table(  # noqa
+        "releases_json_scheduled_changes_signoffs",
+        metadata,
+        Column("sc_id", Integer, primary_key=True, autoincrement=False),
+        Column("username", String(100), primary_key=True),
+        Column("role", String(50), nullable=False),
+    )
+
+    releases_json_scheduled_changes_signoffs_history = Table(  # noqa
+        "releases_json_scheduled_changes_signoffs_history",
+        metadata,
+        Column("change_id", Integer, primary_key=True, autoincrement=True),
+        Column("changed_by", String(100), nullable=False),
+        Column("timestamp", bigintType, nullable=False),
+        Column("sc_id", Integer, nullable=False, autoincrement=False),
+        Column("username", String(100), nullable=False),
+        Column("role", String(50)),
+    )
+
+    release_assets = Table(  # noqa
+        "release_assets",
+        metadata,
+        Column("name", String(100), primary_key=True),
+        Column("path", String(200), primary_key=True),
+        Column("data", JSON),
+        Column("data_version", Integer, nullable=False),
+    )
+
+    release_assets_scheduled_changes = Table(  # noqa
+        "release_assets_scheduled_changes",
+        metadata,
+        Column("sc_id", Integer, primary_key=True, autoincrement=True),
+        Column("scheduled_by", String(100), nullable=False),
+        Column("complete", Boolean, default=False),
+        Column("change_type", String(50), nullable=False),
+        Column("data_version", Integer, nullable=False),
+        Column("base_name", String(100), nullable=False),
+        Column("base_path", String(200), nullable=False),
+        Column("base_data", JSON),
+        Column("base_data_version", Integer),
+    )
+
+    release_assets_scheduled_changes_history = Table(  # noqa
+        "release_assets_scheduled_changes_history",
+        metadata,
+        Column("change_id", Integer, primary_key=True, autoincrement=True),
+        Column("changed_by", String(100), nullable=False),
+        Column("timestamp", bigintType, nullable=False),
+        Column("sc_id", Integer, nullable=False),
+        Column("scheduled_by", String(100)),
+        Column("complete", Boolean, default=False),
+        Column("change_type", String(50), nullable=True),
+        Column("data_version", Integer),
+        Column("base_name", String(100)),
+        Column("base_path", String(200)),
+        Column("base_data", JSON),
+        Column("base_data_version", Integer),
+    )
+
+    release_assets_scheduled_changes_conditions = Table(  # noqa
+        "release_assets_scheduled_changes_conditions",
+        metadata,
+        Column("sc_id", Integer, primary_key=True, autoincrement=True),
+        Column("when", bigintType),
+        Column("data_version", Integer, nullable=False),
+    )
+
+    release_assets_scheduled_changes_conditions_history = Table(  # noqa
+        "release_assets_scheduled_changes_conditions_history",
+        metadata,
+        Column("change_id", Integer, primary_key=True, autoincrement=True),
+        Column("changed_by", String(100), nullable=False),
+        Column("timestamp", bigintType, nullable=False),
+        Column("sc_id", Integer, nullable=False),
+        Column("when", bigintType),
+        Column("data_version", Integer),
+    )
+
+    release_assets_scheduled_changes_signoffs = Table(  # noqa
+        "release_assets_scheduled_changes_signoffs",
+        metadata,
+        Column("sc_id", Integer, primary_key=True, autoincrement=False),
+        Column("username", String(100), primary_key=True),
+        Column("role", String(50), nullable=False),
+    )
+
+    release_assets_scheduled_changes_signoffs_history = Table(  # noqa
+        "release_assets_scheduled_changes_signoffs_history",
+        metadata,
+        Column("change_id", Integer, primary_key=True, autoincrement=True),
+        Column("changed_by", String(100), nullable=False),
+        Column("timestamp", bigintType, nullable=False),
+        Column("sc_id", Integer, nullable=False, autoincrement=False),
+        Column("username", String(100), nullable=False),
+        Column("role", String(50)),
+    )
+
+    metadata.create_all()
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData(bind=migrate_engine)
+
+    Table("releases_json", metadata, autoload=True).drop()
+    Table("releases_json_scheduled_changes", metadata, autoload=True).drop()
+    Table("releases_json_scheduled_changes_history", metadata, autoload=True).drop()
+    Table("releases_json_scheduled_changes_conditions", metadata, autoload=True).drop()
+    Table("releases_json_scheduled_changes_conditions_history", metadata, autoload=True).drop()
+    Table("releases_json_scheduled_changes_signoffs", metadata, autoload=True).drop()
+    Table("releases_json_scheduled_changes_signoffs_history", metadata, autoload=True).drop()
+    Table("release_assets", metadata, autoload=True).drop()
+    Table("release_assets_scheduled_changes", metadata, autoload=True).drop()
+    Table("release_assets_scheduled_changes_history", metadata, autoload=True).drop()
+    Table("release_assets_scheduled_changes_conditions", metadata, autoload=True).drop()
+    Table("release_assets_scheduled_changes_conditions_history", metadata, autoload=True).drop()
+    Table("release_assets_scheduled_changes_signoffs", metadata, autoload=True).drop()
+    Table("release_assets_scheduled_changes_signoffs_history", metadata, autoload=True).drop()

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -21,9 +21,9 @@ class FakeBucket:
 
 
 class FakeGCSHistory(GCSHistory):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, identifier_columns=["name"], **kwargs):
         self.bucket = FakeBucket()
-        self.identifier_column = "name"
+        self.identifier_columns = identifier_columns
         self.data_column = "data"
 
     def _getBucket(self, identifier):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -5619,6 +5619,20 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
                 "releases_scheduled_changes_history",
                 "releases_scheduled_changes_signoffs",
                 "releases_scheduled_changes_signoffs_history",
+                "releases_json",
+                "releases_json_scheduled_changes",
+                "releases_json_scheduled_changes_conditions",
+                "releases_json_scheduled_changes_conditions_history",
+                "releases_json_scheduled_changes_history",
+                "releases_json_scheduled_changes_signoffs",
+                "releases_json_scheduled_changes_signoffs_history",
+                "release_assets",
+                "release_assets_scheduled_changes",
+                "release_assets_scheduled_changes_conditions",
+                "release_assets_scheduled_changes_conditions_history",
+                "release_assets_scheduled_changes_history",
+                "release_assets_scheduled_changes_signoffs",
+                "release_assets_scheduled_changes_signoffs_history",
                 "rules",
                 "rules_history",
                 "rules_scheduled_changes",
@@ -5899,6 +5913,31 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             for table in shutoff_tables:
                 self.assertNotIn(table, metadata.tables)
 
+    def _add_release_json_tables(self, db, upgrade=True):
+        metadata = self._get_reflected_metadata(db)
+        shutoff_tables = [
+            "releases_json",
+            "releases_json_scheduled_changes",
+            "releases_json_scheduled_changes_history",
+            "releases_json_scheduled_changes_conditions",
+            "releases_json_scheduled_changes_conditions_history",
+            "releases_json_scheduled_changes_signoffs",
+            "releases_json_scheduled_changes_signoffs_history",
+            "release_assets",
+            "release_assets_scheduled_changes",
+            "release_assets_scheduled_changes_history",
+            "release_assets_scheduled_changes_conditions",
+            "release_assets_scheduled_changes_conditions_history",
+            "release_assets_scheduled_changes_signoffs",
+            "release_assets_scheduled_changes_signoffs_history",
+        ]
+        if upgrade:
+            for table in shutoff_tables:
+                self.assertIn(table, metadata.tables)
+        else:
+            for table in shutoff_tables:
+                self.assertNotIn(table, metadata.tables)
+
     def _fix_column_attributes_migration_test(self, db, upgrade=True):
         """
         Tests the upgrades and downgrades for version 22 work properly.
@@ -5966,6 +6005,7 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
 
         versions_migrate_tests_dict = {
             # This version removes the releases_history table, which is verified by other tests
+            33: self._add_release_json_tables,
             32: _noop,
             31: self._test_rules_longer_distribution,
             30: self._add_emergency_shutoff_tables,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6056,7 +6056,7 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
 
     def _add_release_json_tables(self, db, upgrade=True):
         metadata = self._get_reflected_metadata(db)
-        shutoff_tables = [
+        releases_tables = [
             "releases_json",
             "releases_json_scheduled_changes",
             "releases_json_scheduled_changes_history",
@@ -6073,10 +6073,10 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             "release_assets_scheduled_changes_signoffs_history",
         ]
         if upgrade:
-            for table in shutoff_tables:
+            for table in releases_tables:
                 self.assertIn(table, metadata.tables)
         else:
-            for table in shutoff_tables:
+            for table in releases_tables:
                 self.assertNotIn(table, metadata.tables)
 
     def _fix_column_attributes_migration_test(self, db, upgrade=True):
@@ -6145,8 +6145,8 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             pass
 
         versions_migrate_tests_dict = {
-            # This version removes the releases_history table, which is verified by other tests
             33: self._add_release_json_tables,
+            # This version removes the releases_history table, which is verified by other tests
             32: _noop,
             31: self._test_rules_longer_distribution,
             30: self._add_emergency_shutoff_tables,


### PR DESCRIPTION
Adds the new tables needed to start implementing split table Releases. The most notable part of this is enhancing `GCSHistory` to handle multiple part keys.

Eventually I intend to migrate all of the `Releases` table into the new tables (TBD is whether or not we'll split them, or just let them fully live in `ReleasesJSON`.