### PR TITLE
Finishing touches on new Releases API

### DIFF
--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -2412,6 +2412,18 @@ class ReleasesJSON(AUSTable):
 
         return potential_required_signoffs
 
+    def getPotentialRequiredSignoffsForProduct(self, product, transaction=None):
+        potential_required_signoffs = {"rs": []}
+        where = [self.db.productRequiredSignoffs.product == product]
+        product_rs = self.db.productRequiredSignoffs.select(where=where, transaction=transaction)
+        if product_rs:
+            role_map = defaultdict(list)
+            for rs in product_rs:
+                role_map[rs["role"]].append(rs)
+            signoffs_required = [max(signoffs, default=None, key=lambda k: k["signoffs_required"]) for signoffs in role_map.values()]
+            potential_required_signoffs["rs"] = signoffs_required
+        return potential_required_signoffs
+
 
 class ReleaseAssets(AUSTable):
     def __init__(self, db, metadata, dialect, history_buckets, historyClass):

--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -1488,7 +1488,6 @@ class ScheduledChangeTable(AUSTable):
         if change_type == "delete":
             where = []
             for col in self.base_primary_key:
-                print(sc["base_%s" % col])
                 where.append((getattr(self.baseTable, col) == sc["base_%s" % col]))
             await self.baseTable.async_delete(where, sc["scheduled_by"], sc["base_data_version"], transaction=transaction, signoffs=signoffs)
         elif change_type == "update":
@@ -2477,8 +2476,6 @@ class ReleasesJSON(AUSTable):
     async def async_insert(self, changed_by, transaction=None, dryrun=False, signoffs=None, **columns):
         if not dryrun:
             potential_required_signoffs = [obj for v in self.getPotentialRequiredSignoffs([columns], transaction=transaction).values() for obj in v]
-            print(potential_required_signoffs)
-            print(signoffs)
             verify_signoffs(potential_required_signoffs, signoffs)
 
         return await super(ReleasesJSON, self).async_insert(changed_by=changed_by, transaction=transaction, dryrun=dryrun, **columns)

--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -1452,7 +1452,7 @@ class ScheduledChangeTable(AUSTable):
         return ret
 
     async def asyncEnactChange(self, sc_id, enacted_by, transaction=None):
-        """Enacts a previously scheduled change by running update or insert on
+        """Enacts a previously scheduled change by running update, insert, or delete on
         the base table."""
         if not self.db.hasPermission(enacted_by, "scheduled_change", "enact", transaction=transaction):
             raise PermissionDeniedError("%s is not allowed to enact scheduled changes", enacted_by)
@@ -1501,7 +1501,7 @@ class ScheduledChangeTable(AUSTable):
             raise ValueError("Unknown Change Type")
 
     def enactChange(self, sc_id, enacted_by, transaction=None):
-        """Enacts a previously scheduled change by running update or insert on
+        """Enacts a previously scheduled change by running update, insert, or delete on
         the base table."""
         if not self.db.hasPermission(enacted_by, "scheduled_change", "enact", transaction=transaction):
             raise PermissionDeniedError("%s is not allowed to enact scheduled changes", enacted_by)

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -312,8 +312,7 @@ def get_release(name, trans):
     if scheduled_row:
         sc_data_versions["."] = scheduled_row[0]["data_version"]
         if scheduled_row[0]["change_type"] != "delete":
-            sc_blob = deepcopy(base_blob)
-            sc_blob.update(scheduled_row[0]["base_data"])
+            sc_blob = scheduled_row[0]["base_data"]
 
     for asset in dbo.release_assets.select(where={"name": name}, transaction=trans):
         path = asset["path"].split(".")[1:]
@@ -328,6 +327,10 @@ def get_release(name, trans):
         path = scheduled_asset["base_path"].split(".")[1:]
         set_by_path(sc_data_versions, path, scheduled_asset["data_version"])
         if scheduled_asset["change_type"] != "delete":
+            # This won't exist yet unless the base part of the Release also has a change scheduled
+            if not sc_blob:
+                sc_blob = deepcopy(base_blob)
+
             ensure_path_exists(sc_blob, path)
             set_by_path(sc_blob, path, scheduled_asset["base_data"])
 

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -12,8 +12,8 @@ from ..blobs.base import createBlob
 from ..errors import PermissionDeniedError, ReadOnlyError, SignoffRequiredError
 from ..global_state import dbo
 from ..util.data_structures import ensure_path_exists, get_by_path, infinite_defaultdict, set_by_path
+from ..util.signoffs import serialize_signoff_requirements
 from ..util.timestamp import getMillisecondTimestamp
-from ..web.admin.views.base import serialize_signoff_requirements  # todo: moveme
 
 log = logging.getLogger(__file__)
 

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -308,7 +308,7 @@ def get_release(name, trans):
         base_blob = base_row[0]["data"]
         data_versions["."] = base_row[0]["data_version"]
 
-    scheduled_row = dbo.releases_json.scheduled_changes.select(where={"base_name": name}, transaction=trans)
+    scheduled_row = dbo.releases_json.scheduled_changes.select(where={"base_name": name, "complete": False}, transaction=trans)
     if scheduled_row:
         sc_data_versions["."] = scheduled_row[0]["data_version"]
         if scheduled_row[0]["change_type"] != "delete":
@@ -324,7 +324,7 @@ def get_release(name, trans):
             ensure_path_exists(sc_blob, path)
             set_by_path(sc_blob, path, asset["data"])
 
-    for scheduled_asset in dbo.release_assets.scheduled_changes.select(where={"base_name": name}, transaction=trans):
+    for scheduled_asset in dbo.release_assets.scheduled_changes.select(where={"base_name": name, "complete": False}, transaction=trans):
         path = scheduled_asset["base_path"].split(".")[1:]
         set_by_path(sc_data_versions, path, scheduled_asset["data_version"])
         if scheduled_asset["change_type"] != "delete":

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -561,9 +561,7 @@ def set_release(name, blob, product, old_data_versions, when, changed_by, trans)
             dbo.releases_json.scheduled_changes.delete(where={"base_name": name, "complete": False}, old_data_version=sc[0]["data_version"], changed_by=changed_by, transaction=trans)
     else:
         if old_data_versions.get("."):
-            what = {"data": base_blob}
-            if product:
-                what["product"] = product
+            what = {"data": base_blob, "product": product or current_product}
             if when:
                 sc_id = dbo.releases_json.scheduled_changes.insert(
                     name=name, data_version=old_data_versions["."], when=when, change_type="update", changed_by=changed_by, transaction=trans, **what

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -402,7 +402,10 @@ def update_release(name, blob, old_data_versions, when, changed_by, trans):
                 changed_by=changed_by,
                 transaction=trans,
             )
-            new_data_versions["."] = {"sc_id": sc_id, "change_type": "update", "data_version": 1}
+            signoffs = {}
+            for signoff in dbo.releases_json.scheduled_changes.signoffs.select(where={"sc_id": sc_id}, transaction=trans):
+                signoffs[signoff["username"]] = signoff["role"]
+            new_data_versions["."] = {"sc_id": sc_id, "change_type": "update", "data_version": 1, "signoffs": signoffs, "when": when}
         else:
             coro = dbo.releases_json.async_update(
                 where={"name": name}, what={"data": new_base_blob}, old_data_version=old_data_versions["."], changed_by=changed_by, transaction=trans
@@ -432,7 +435,10 @@ def update_release(name, blob, old_data_versions, when, changed_by, trans):
                         changed_by=changed_by,
                         transaction=trans,
                     )
-                    set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "update", "data_version": 1})
+                    signoffs = {}
+                    for signoff in dbo.release_assets.scheduled_changes.signoffs.select(where={"sc_id": sc_id}, transaction=trans):
+                        signoffs[signoff["username"]] = signoff["role"]
+                    set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "update", "data_version": 1, "signoffs": signoffs, "when": when})
                 else:
                     coro = dbo.release_assets.async_update(
                         where={"name": name, "path": str_path},
@@ -448,7 +454,10 @@ def update_release(name, blob, old_data_versions, when, changed_by, trans):
                 sc_id = dbo.release_assets.scheduled_changes.insert(
                     name=name, path=str_path, data=item, when=when, change_type="insert", changed_by=changed_by, transaction=trans,
                 )
-                set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "insert", "data_version": 1})
+                signoffs = {}
+                for signoff in dbo.release_assets.scheduled_changes.signoffs.select(where={"sc_id": sc_id}, transaction=trans):
+                    signoffs[signoff["username"]] = signoff["role"]
+                set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "insert", "data_version": 1, "signoffs": signoffs, "when": when})
             else:
                 coro = dbo.release_assets.async_insert(name=name, path=str_path, data=item, changed_by=changed_by, transaction=trans)
                 coros.append(coro)
@@ -528,7 +537,10 @@ def set_release(name, blob, product, old_data_versions, when, changed_by, trans)
                     changed_by=changed_by,
                     transaction=trans,
                 )
-                set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "update", "data_version": 1})
+                signoffs = {}
+                for signoff in dbo.release_assets.scheduled_changes.signoffs.select(where={"sc_id": sc_id}, transaction=trans):
+                    signoffs[signoff["username"]] = signoff["role"]
+                set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "update", "data_version": 1, "signoffs": signoffs, "when": when})
             else:
                 coro = dbo.release_assets.async_update(
                     where={"name": name, "path": str_path}, what={"data": item}, old_data_version=old_data_version, changed_by=changed_by, transaction=trans
@@ -540,7 +552,10 @@ def set_release(name, blob, product, old_data_versions, when, changed_by, trans)
                 sc_id = dbo.release_assets.scheduled_changes.insert(
                     name=name, path=str_path, data=item, when=when, change_type="insert", changed_by=changed_by, transaction=trans
                 )
-                set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "insert", "data_version": 1})
+                signoffs = {}
+                for signoff in dbo.release_assets.scheduled_changes.signoffs.select(where={"sc_id": sc_id}, transaction=trans):
+                    signoffs[signoff["username"]] = signoff["role"]
+                set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "insert", "data_version": 1, "signoffs": signoffs, "when": when})
             else:
                 coro = dbo.release_assets.async_insert(name=name, path=str_path, data=item, changed_by=changed_by, transaction=trans)
                 coros.append(coro)
@@ -559,7 +574,10 @@ def set_release(name, blob, product, old_data_versions, when, changed_by, trans)
                 changed_by=changed_by,
                 transaction=trans,
             )
-            set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "delete", "data_version": 1})
+            signoffs = {}
+            for signoff in dbo.release_assets.scheduled_changes.signoffs.select(where={"sc_id": sc_id}, transaction=trans):
+                signoffs[signoff["username"]] = signoff["role"]
+            set_by_path(new_data_versions, path, {"sc_id": sc_id, "change_type": "delete", "data_version": 1, "signoffs": signoffs, "when": when})
         else:
             coro = dbo.release_assets.async_delete(
                 where={"name": name, "path": str_path}, old_data_version=get_by_path(old_data_versions, path), changed_by=changed_by, transaction=trans
@@ -583,7 +601,10 @@ def set_release(name, blob, product, old_data_versions, when, changed_by, trans)
                 sc_id = dbo.releases_json.scheduled_changes.insert(
                     name=name, data_version=old_data_versions["."], when=when, change_type="update", changed_by=changed_by, transaction=trans, **what
                 )
-                new_data_versions["."] = {"sc_id": sc_id, "change_type": "update", "data_version": 1}
+                signoffs = {}
+                for signoff in dbo.releases_json.scheduled_changes.signoffs.select(where={"sc_id": sc_id}, transaction=trans):
+                    signoffs[signoff["username"]] = signoff["role"]
+                new_data_versions["."] = {"sc_id": sc_id, "change_type": "update", "data_version": 1, "signoffs": signoffs, "when": when}
             else:
                 coro = dbo.releases_json.async_update(
                     where={"name": name}, what=what, old_data_version=old_data_versions["."], changed_by=changed_by, transaction=trans

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -501,7 +501,7 @@ def set_release(name, blob, product, old_data_versions, when, changed_by, trans)
     current_assets = get_assets(name, trans)
     base_blob, new_assets = split_release(blob, blob["schema_version"])
 
-    # if current != new, we will just be cancelling a scheduled change
+    # if current == new, we will just be cancelling a scheduled change
     if current_base_blob != base_blob and current_assets != new_assets and not when and any([v for v in live_on_product_channels.values()]):
         raise SignoffRequiredError("Signoff is required, cannot update Release directly")
 
@@ -641,7 +641,6 @@ def delete_release(name, changed_by, trans):
         if row:
             row = row[0]
             sc_id = row["sc_id"]
-            product = row["base_product"]
             old_data_version = row["data_version"]
 
             dbo.releases_json.scheduled_changes.delete(where={"sc_id": sc_id}, old_data_version=old_data_version, changed_by=changed_by, transaction=trans)
@@ -650,7 +649,6 @@ def delete_release(name, changed_by, trans):
             where={"base_name": name, "complete": False},
             columns=[
                 dbo.release_assets.scheduled_changes.sc_id,
-                dbo.release_assets.scheduled_changes.base_path,
                 dbo.release_assets.scheduled_changes.data_version,
             ],
         ):

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -650,10 +650,7 @@ def delete_release(name, changed_by, trans):
 
         for asset in dbo.release_assets.scheduled_changes.select(
             where={"base_name": name, "complete": False},
-            columns=[
-                dbo.release_assets.scheduled_changes.sc_id,
-                dbo.release_assets.scheduled_changes.data_version,
-            ],
+            columns=[dbo.release_assets.scheduled_changes.sc_id, dbo.release_assets.scheduled_changes.data_version],
         ):
             dbo.release_assets.scheduled_changes.delete(
                 where={"sc_id": asset["sc_id"]}, old_data_version=asset["data_version"], changed_by=changed_by, transaction=trans

--- a/src/auslib/util/signoffs.py
+++ b/src/auslib/util/signoffs.py
@@ -1,0 +1,7 @@
+def serialize_signoff_requirements(requirements):
+    dct = {}
+    for rs in requirements:
+        signoffs_required = max(dct.get(rs["role"], 0), rs["signoffs_required"])
+        dct[rs["role"]] = signoffs_required
+
+    return dct

--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -135,6 +135,8 @@ def unicode(error):
 def ise(error):
     capture_exception(error)
     log.error("Caught ISE 500 error.")
+    print(error)
+    raise error
     log.debug("Request path is: %s", request.path)
     log.debug("Request environment is: %s", request.environ)
     log.debug("Request headers are: %s", request.headers)

--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -135,8 +135,6 @@ def unicode(error):
 def ise(error):
     capture_exception(error)
     log.error("Caught ISE 500 error.")
-    print(error)
-    raise error
     log.debug("Request path is: %s", request.path)
     log.debug("Request environment is: %s", request.environ)
     log.debug("Request headers are: %s", request.headers)

--- a/src/auslib/web/admin/swagger/api_v2.yml
+++ b/src/auslib/web/admin/swagger/api_v2.yml
@@ -319,6 +319,23 @@ paths:
         '404':
           description: Release not found
 
+  /releases/{name}/enact:
+    parameters:
+      - $ref: '#/components/parameters/ReleaseName'
+
+    post:
+      summary: Enact the current scheduled changes for the named Release
+      operationId: auslib.web.admin.views.releases_v2.enact_scheduled_changes
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: Client error
+        '403':
+          description: Permission denied
+        '404':
+          description: Release has no scheduled changes
+        
   /releases/{name}/{path}/data_version:
     parameters:
       - $ref: '#/components/parameters/ReleaseName'

--- a/src/auslib/web/admin/swagger/api_v2.yml
+++ b/src/auslib/web/admin/swagger/api_v2.yml
@@ -21,6 +21,11 @@ components:
           type: number
           nullable: true
 
+    RequiredSignoffs:
+      type: object
+      additionalProperties:
+        type: integer
+
     ReleaseModifyBody:
       type: object
       required:
@@ -41,6 +46,8 @@ components:
         - sc_id
         - change_type
         - data_version
+        - when
+        - signoffs
       properties:
         sc_id:
           type: number
@@ -52,6 +59,12 @@ components:
             - delete
         data_version:
           type: number
+        when:
+          type: integer
+        signoffs:
+          type: object
+          additionalProperties:
+            type: string
 
     ReleaseModifyResponseLeaf:
       oneOf:
@@ -114,6 +127,10 @@ paths:
                             - name
                             - rule_info
                           properties:
+                            product_required_signoffs:
+                              $ref: '#/components/schemas/RequiredSignoffs'
+                            required_signoffs:
+                              $ref: '#/components/schemas/RequiredSignoffs'
                             read_only:
                               nullable: false
                             rule_info:

--- a/src/auslib/web/admin/views/base.py
+++ b/src/auslib/web/admin/views/base.py
@@ -116,12 +116,3 @@ class AdminView(MethodView):
     def delete(self, *args, **kwargs):
         self.log.debug("processing DELETE request to %s" % request.path)
         return self._delete(*args, **kwargs)
-
-
-def serialize_signoff_requirements(requirements):
-    dct = {}
-    for rs in requirements:
-        signoffs_required = max(dct.get(rs["role"], 0), rs["signoffs_required"])
-        dct[rs["role"]] = signoffs_required
-
-    return dct

--- a/src/auslib/web/admin/views/releases.py
+++ b/src/auslib/web/admin/views/releases.py
@@ -8,7 +8,8 @@ from auslib.blobs.base import createBlob
 from auslib.db import OutdatedDataError
 from auslib.errors import BlobValidationError, ReadOnlyError
 from auslib.global_state import dbo
-from auslib.web.admin.views.base import AdminView, requirelogin, serialize_signoff_requirements
+from auslib.util.signoffs import serialize_signoff_requirements
+from auslib.web.admin.views.base import AdminView, requirelogin
 from auslib.web.admin.views.problem import problem
 from auslib.web.admin.views.scheduled_changes import (
     EnactScheduledChangeView,

--- a/src/auslib/web/admin/views/releases_v2.py
+++ b/src/auslib/web/admin/views/releases_v2.py
@@ -75,6 +75,7 @@ def revoke_signoff(name):
     ret = releases.revoke_signoff(name, request.username, request.transaction)
     return ret, 200
 
+
 def enact_scheduled_changes(name):
     if not releases.sc_exists(name, request.transaction):
         return problem(404, "Missing", "Release has no scheduled changes")

--- a/src/auslib/web/admin/views/releases_v2.py
+++ b/src/auslib/web/admin/views/releases_v2.py
@@ -74,3 +74,9 @@ def revoke_signoff(name):
         return problem(404, "Missing", "Release has no scheduled changes")
     ret = releases.revoke_signoff(name, request.username, request.transaction)
     return ret, 200
+
+def enact_scheduled_changes(name):
+    if not releases.sc_exists(name, request.transaction):
+        return problem(404, "Missing", "Release has no scheduled changes")
+    ret = releases.enact_scheduled_changes(name, request.username, request.transaction)
+    return ret, 200

--- a/src/auslib/web/admin/views/rules.py
+++ b/src/auslib/web/admin/views/rules.py
@@ -21,7 +21,10 @@ def process_rule_form(form_data):
     :param form_data: input json form data in dict
     :return: dictionary of processed form field values and list of valid mapping key's value.
     """
-    release_names = dbo.releases.getReleaseNames()
+    release_names = [
+        *dbo.releases.getReleaseNames(),
+        *dbo.releases_json.select(columns=[dbo.releases_json.name]),
+    ]
 
     mapping_choices = [(item["name"], item["name"]) for item in release_names]
 

--- a/src/auslib/web/admin/views/scheduled_changes.py
+++ b/src/auslib/web/admin/views/scheduled_changes.py
@@ -2,7 +2,8 @@ import connexion
 from flask import jsonify
 from sqlalchemy.sql.expression import null
 
-from auslib.web.admin.views.base import AdminView, requirelogin, serialize_signoff_requirements
+from auslib.util.signoffs import serialize_signoff_requirements
+from auslib.web.admin.views.base import AdminView, requirelogin
 from auslib.web.admin.views.history import HistoryView
 from auslib.web.admin.views.problem import problem
 from auslib.web.admin.views.validators import is_when_present_and_in_past_validator

--- a/tests/admin/views/test_releases_v2.py
+++ b/tests/admin/views/test_releases_v2.py
@@ -969,9 +969,21 @@ def test_put_cancels_scheduled_updates(api, firefox_66_0_build1):
     ret = api.put("/v2/releases/Firefox-66.0-build1", json={"blob": firefox_66_0_build1, "product": "Firefox", "old_data_versions": old_data_versions})
     assert ret.status_code == 200, ret.data
 
-    base_sc = dbo.releases_json.scheduled_changes.t.select().where(dbo.releases_json.scheduled_changes.base_name == "Firefox-66.0-build1").where(dbo.releases_json.scheduled_changes.complete == False).execute().fetchall()
+    base_sc = (
+        dbo.releases_json.scheduled_changes.t.select()
+        .where(dbo.releases_json.scheduled_changes.base_name == "Firefox-66.0-build1")
+        .where(dbo.releases_json.scheduled_changes.complete is False)
+        .execute()
+        .fetchall()
+    )
     assert len(base_sc) == 0
-    locale_sc = dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1").where(dbo.release_assets.scheduled_changes.complete == False).execute().fetchall()
+    locale_sc = (
+        dbo.release_assets.scheduled_changes.t.select()
+        .where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1")
+        .where(dbo.release_assets.scheduled_changes.complete is False)
+        .execute()
+        .fetchall()
+    )
     assert len(locale_sc) == 0
 
 
@@ -1935,9 +1947,17 @@ def test_revoke_signoff(api):
 
 @pytest.mark.usefixtures("releases_db", "mock_verified_userinfo")
 def test_enact_changes_missing_signoff(api):
-    sc_id = dbo.releases_json.scheduled_changes.t.select().where(dbo.releases_json.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchone().sc_id
+    sc_id = (
+        dbo.releases_json.scheduled_changes.t.select().where(dbo.releases_json.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchone().sc_id
+    )
     dbo.releases_json.scheduled_changes.signoffs.t.delete().where(dbo.releases_json.scheduled_changes.signoffs.sc_id == sc_id).execute()
-    for sc in dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1").where(dbo.release_assets.scheduled_changes.base_path == ".platforms.WINNT_x86_64-msvc.locales.en-US").execute().fetchall():
+    for sc in (
+        dbo.release_assets.scheduled_changes.t.select()
+        .where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1")
+        .where(dbo.release_assets.scheduled_changes.base_path == ".platforms.WINNT_x86_64-msvc.locales.en-US")
+        .execute()
+        .fetchall()
+    ):
         dbo.release_assets.scheduled_changes.signoffs.t.delete().where(dbo.release_assets.scheduled_changes.signoffs.sc_id == sc_id).execute()
     ret = api.post("/v2/releases/Firefox-66.0-build1/enact")
     assert ret.status_code == 400
@@ -1964,7 +1984,9 @@ def test_enact_insert(api):
 
     base_sc = dbo.releases_json.scheduled_changes.t.select().where(dbo.releases_json.scheduled_changes.base_name == "Firefox-64.0-build1").execute().fetchone()
     assert base_sc["complete"] is True
-    locale_scs = dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-64.0-build1").execute().fetchall()
+    locale_scs = (
+        dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-64.0-build1").execute().fetchall()
+    )
     print(locale_scs)
     assert all([sc["complete"] for sc in locale_scs])
 
@@ -1981,7 +2003,9 @@ def test_enact_update(api):
 
     base_sc = dbo.releases_json.scheduled_changes.t.select().where(dbo.releases_json.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchone()
     assert base_sc["complete"] is True
-    locale_scs = dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchall()
+    locale_scs = (
+        dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchall()
+    )
     print(locale_scs)
     assert all([sc["complete"] for sc in locale_scs])
 
@@ -2001,7 +2025,9 @@ def test_enact_delete(api):
 
     base_sc = dbo.releases_json.scheduled_changes.t.select().where(dbo.releases_json.scheduled_changes.base_name == "Firefox-67.0-build1").execute().fetchone()
     assert base_sc["complete"] is True
-    locale_scs = dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-67.0-build1").execute().fetchall()
+    locale_scs = (
+        dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-67.0-build1").execute().fetchall()
+    )
     print(locale_scs)
     assert all([sc["complete"] for sc in locale_scs])
 
@@ -2013,7 +2039,14 @@ def test_enact_delete(api):
 
 @pytest.mark.usefixtures("releases_db", "mock_verified_userinfo")
 def test_enact_changes_one_fails_all_revert(api):
-    sc_id = dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1").where(dbo.release_assets.scheduled_changes.base_path == ".platforms.WINNT_x86_64-msvc.locales.en-US").execute().fetchone().sc_id
+    sc_id = (
+        dbo.release_assets.scheduled_changes.t.select()
+        .where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1")
+        .where(dbo.release_assets.scheduled_changes.base_path == ".platforms.WINNT_x86_64-msvc.locales.en-US")
+        .execute()
+        .fetchone()
+        .sc_id
+    )
     dbo.release_assets.scheduled_changes.signoffs.t.delete().where(dbo.release_assets.scheduled_changes.signoffs.sc_id == sc_id).execute()
 
     ret = api.post("/v2/releases/Firefox-66.0-build1/enact")
@@ -2022,7 +2055,9 @@ def test_enact_changes_one_fails_all_revert(api):
 
     base_sc = dbo.releases_json.scheduled_changes.t.select().where(dbo.releases_json.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchone()
     assert base_sc["complete"] is False
-    locale_scs = dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchall()
+    locale_scs = (
+        dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchall()
+    )
     assert all([not sc["complete"] for sc in locale_scs])
 
     base_blob = dbo.releases_json.t.select().where(dbo.releases_json.name == "Firefox-66.0-build1").execute().fetchone().data

--- a/tests/admin/views/test_releases_v2.py
+++ b/tests/admin/views/test_releases_v2.py
@@ -1332,7 +1332,7 @@ def test_put_add_scheduled_change_base_only(api, firefox_56_0_build1):
 
     old_data_versions = versions_dict()
     old_data_versions["."] = 1
-    new_data_versions = {".": {"sc_id": 4, "data_version": 1, "change_type": "update"}}
+    new_data_versions = {".": {"sc_id": 4, "data_version": 1, "change_type": "update", "signoffs": {"bob": "releng"}, "when": 1681639932000}}
 
     ret = api.put(
         "/v2/releases/Firefox-56.0-build1",
@@ -1382,7 +1382,13 @@ def test_put_add_scheduled_change_locale_only(api, firefox_56_0_build1):
 
     old_data_versions = versions_dict()
     assert old_data_versions["platforms"]["Linux_x86_64-gcc3"]["locales"]["en-US"]
-    new_data_versions = {"platforms": {"Linux_x86_64-gcc3": {"locales": {"en-US": {"sc_id": 18, "data_version": 1, "change_type": "update"}}}}}
+    new_data_versions = {
+        "platforms": {
+            "Linux_x86_64-gcc3": {
+                "locales": {"en-US": {"sc_id": 18, "data_version": 1, "change_type": "update", "signoffs": {"bob": "releng"}, "when": 1681639932000}}
+            }
+        }
+    }
 
     ret = api.put(
         "/v2/releases/Firefox-56.0-build1",
@@ -1434,8 +1440,12 @@ def test_put_add_scheduled_change_base_and_locale(api, firefox_56_0_build1):
     old_data_versions["."] = 1
     assert old_data_versions["platforms"]["Linux_x86_64-gcc3"]["locales"]["en-US"]
     new_data_versions = {
-        ".": {"sc_id": 4, "data_version": 1, "change_type": "update"},
-        "platforms": {"Linux_x86_64-gcc3": {"locales": {"en-US": {"sc_id": 18, "data_version": 1, "change_type": "update"}}}},
+        ".": {"sc_id": 4, "data_version": 1, "change_type": "update", "signoffs": {"bob": "releng"}, "when": 1681639932000},
+        "platforms": {
+            "Linux_x86_64-gcc3": {
+                "locales": {"en-US": {"sc_id": 18, "data_version": 1, "change_type": "update", "signoffs": {"bob": "releng"}, "when": 1681639932000}}
+            }
+        },
     }
 
     ret = api.put(
@@ -1520,7 +1530,7 @@ def test_post_add_scheduled_change_base_only(api, firefox_56_0_build1):
 
     old_data_versions = versions_dict()
     old_data_versions["."] = 1
-    new_data_versions = {".": {"sc_id": 4, "data_version": 1, "change_type": "update"}}
+    new_data_versions = {".": {"sc_id": 4, "data_version": 1, "change_type": "update", "signoffs": {"bob": "releng"}, "when": 1681639932000}}
 
     ret = api.post(
         "/v2/releases/Firefox-56.0-build1",
@@ -1571,7 +1581,13 @@ def test_post_add_scheduled_change_locale_only(api, firefox_56_0_build1):
 
     old_data_versions = versions_dict()
     assert old_data_versions["platforms"]["Linux_x86_64-gcc3"]["locales"]["en-US"]
-    new_data_versions = {"platforms": {"Linux_x86_64-gcc3": {"locales": {"en-US": {"sc_id": 18, "data_version": 1, "change_type": "update"}}}}}
+    new_data_versions = {
+        "platforms": {
+            "Linux_x86_64-gcc3": {
+                "locales": {"en-US": {"sc_id": 18, "data_version": 1, "change_type": "update", "signoffs": {"bob": "releng"}, "when": 1681639932000}}
+            }
+        }
+    }
 
     ret = api.post(
         "/v2/releases/Firefox-56.0-build1", json={"blob": blob, "product": "Firefox", "old_data_versions": old_data_versions, "when": 1681639932000},
@@ -1622,8 +1638,12 @@ def test_post_add_scheduled_change_base_and_locale(api, firefox_56_0_build1):
     old_data_versions["."] = 1
     assert old_data_versions["platforms"]["Linux_x86_64-gcc3"]["locales"]["en-US"]
     new_data_versions = {
-        ".": {"sc_id": 4, "data_version": 1, "change_type": "update"},
-        "platforms": {"Linux_x86_64-gcc3": {"locales": {"en-US": {"sc_id": 18, "data_version": 1, "change_type": "update"}}}},
+        ".": {"sc_id": 4, "data_version": 1, "change_type": "update", "signoffs": {"bob": "releng"}, "when": 1681639932000},
+        "platforms": {
+            "Linux_x86_64-gcc3": {
+                "locales": {"en-US": {"sc_id": 18, "data_version": 1, "change_type": "update", "signoffs": {"bob": "releng"}, "when": 1681639932000}}
+            }
+        },
     }
 
     ret = api.post(

--- a/tests/admin/views/test_releases_v2.py
+++ b/tests/admin/views/test_releases_v2.py
@@ -1987,7 +1987,6 @@ def test_enact_insert(api):
     locale_scs = (
         dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-64.0-build1").execute().fetchall()
     )
-    print(locale_scs)
     assert all([sc["complete"] for sc in locale_scs])
 
     base_row = dbo.releases_json.t.select().where(dbo.releases_json.name == "Firefox-64.0-build1").execute().fetchone()
@@ -2006,7 +2005,6 @@ def test_enact_update(api):
     locale_scs = (
         dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-66.0-build1").execute().fetchall()
     )
-    print(locale_scs)
     assert all([sc["complete"] for sc in locale_scs])
 
     base_row = dbo.releases_json.t.select().where(dbo.releases_json.name == "Firefox-66.0-build1").execute().fetchone()
@@ -2028,7 +2026,6 @@ def test_enact_delete(api):
     locale_scs = (
         dbo.release_assets.scheduled_changes.t.select().where(dbo.release_assets.scheduled_changes.base_name == "Firefox-67.0-build1").execute().fetchall()
     )
-    print(locale_scs)
     assert all([sc["complete"] for sc in locale_scs])
 
     base_row = dbo.releases_json.t.select().where(dbo.releases_json.name == "Firefox-67.0-build1").execute().fetchone()


### PR DESCRIPTION
This patch adds what should be the final changes to the new Releases API for the time being. I uncovered a few bugs and needed features while working on #1290 and #1266, which this PR addresses. The changesets aren't as well organized as previous patches, but here's the overall highlights:
* Add an endpoint that can enact V2 release scheduled changes
* Add `required_signoffs` and `product_required_signoffs` to `/v2/releases` response
* Make it possible to cancel existing scheduled changes with `PUT` to `/v2/releases/{name}`. This can be done by posting the current version of the Release. This was needed to make it possible to edit existing scheduled changes through the UI. (Sidenote: I originally pursued a strategy of having the backend analyze the current release & scheduled change against the new proposed scheduled change, and have it create/modify/delete the release & scheduled changes as necessary -- but it proved extremely unwieldy, and I decided this was probably the better route.)
* Modify Scheduled Change response to include `signoffs` and `when` to allow the UI to update properly.
* Update rule edit endpoints to allow V2 Releases to be used in Rules
* Fix bug where `sc_blob` was being partly populated in `/v2/releases/{name}` response when only an asset had a scheduled change (ie: no scheduled change to the base)
* Ignore signoff requirements when marking a Release read only
* Fix a few cases where we treating completed scheduled changes as still active
* Always set `product` when scheduling changes in `set_release` to avoid it getting set to None.
* Fix bug where we couldn't delete Releases with scheduled changes, because the database layer complained