### PR TITLE
Add tests to make sure old releases aren't included in new tables and vice versa

### DIFF
--- a/src/auslib/web/admin/views/releases.py
+++ b/src/auslib/web/admin/views/releases.py
@@ -18,7 +18,7 @@ from auslib.web.admin.views.scheduled_changes import (
     ScheduledChangeView,
     SignoffsView,
 )
-from auslib.web.common.releases import release_list, serialize_releases
+from auslib.web.common.releases import serialize_releases
 
 __all__ = ["SingleReleaseView", "SingleLocaleView"]
 
@@ -351,8 +351,15 @@ class ReleasesAPIView(AdminView):
     """/releases"""
 
     def get(self, **kwargs):
-        releases = release_list(connexion.request)
-        if not connexion.request.args.get("names_only"):
+        opts = {}
+        if connexion.request.args.get("product"):
+            opts["product"] = connexion.request.args.get("product")
+        if connexion.request.args.get("name_prefix"):
+            opts["name_prefix"] = connexion.request.args.get("name_prefix")
+        if connexion.request.args.get("names_only"):
+            opts["nameOnly"] = True
+        releases = dbo.releases.getReleaseInfo(**opts)
+        if not opts.get("names_only"):
             requirements = dbo.releases.getPotentialRequiredSignoffs(releases)
             for release in releases:
                 release["required_signoffs"] = serialize_signoff_requirements(requirements[release["name"]])

--- a/tests/admin/views/base.py
+++ b/tests/admin/views/base.py
@@ -23,7 +23,8 @@ class ViewTest(unittest.TestCase):
     """Base class for all view tests. Sets up some sample data, and provides
        some helper methods."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, insert_release, firefox_56_0_build1):
         from auslib.web.admin.views import base as view_base
 
         self.view_base = view_base
@@ -409,7 +410,12 @@ class ViewTest(unittest.TestCase):
         )
         self.client = app.test_client()
 
-    def tearDown(self):
+        # Insert a release into the new tables to make sure it doesn't show up
+        # in the old API.
+        insert_release(firefox_56_0_build1, "Firefox", history=False)
+
+        yield
+
         dbo.reset()
         os.close(self.version_fd)
         os.remove(self.version_file)

--- a/tests/admin/views/test_releases_v2.py
+++ b/tests/admin/views/test_releases_v2.py
@@ -6,6 +6,7 @@ from mock import MagicMock
 
 import auslib.services.releases
 import auslib.util.timestamp
+from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
 from auslib.util.data_structures import deep_dict
 
@@ -90,6 +91,8 @@ def releases_db(
     insert_release_sc(firefox_66_0_build1, "Firefox", signoff_user="bob", signoff_role="releng")
     insert_release(firefox_67_0_build1, "Firefox")
     insert_release_sc(firefox_67_0_build1, "Firefox", change_type="delete", signoff_user="bob", signoff_role="releng")
+    # Insert a Release into the old table to make sure it doesn't show up in the new API
+    dbo.releases.t.insert().execute(name="b", product="b", data=createBlob(dict(name="b", hashFunction="sha512", schema_version=1)), data_version=1)
 
 
 @pytest.mark.usefixtures("releases_db")


### PR DESCRIPTION
This is currently causing 500s in stage, because requests to `/api/releases` are trying to find signoff requirements for v2 releases.