### PR TITLE
Don't query new releases scheduled changes tables in public app

### DIFF
--- a/src/auslib/AUS.py
+++ b/src/auslib/AUS.py
@@ -106,7 +106,7 @@ class AUS:
             if updateQuery["force"] == FORCE_FALLBACK_MAPPING or self.rand() >= rule["backgroundRate"]:
                 fallbackReleaseName = rule["fallbackMapping"]
                 if fallbackReleaseName:
-                    release = releases.get_release(fallbackReleaseName, transaction)
+                    release = releases.get_release(fallbackReleaseName, transaction, include_sc=False)
                     blob = None
                     if release:
                         blob = createBlob(release["blob"])
@@ -125,7 +125,7 @@ class AUS:
         # 3) Incoming release is older than the one in the mapping, defined as one of:
         #    * version decreases
         #    * version is the same and buildID doesn't increase
-        release = releases.get_release(rule["mapping"], transaction)
+        release = releases.get_release(rule["mapping"], transaction, include_sc=False)
         blob = None
         if release:
             blob = createBlob(release["blob"])

--- a/src/auslib/blobs/apprelease.py
+++ b/src/auslib/blobs/apprelease.py
@@ -88,7 +88,7 @@ class ReleaseBlobBase(XMLBlob):
         # even attempt to look it up.
         if patch["from"] != "*":
             try:
-                release = releases.get_release(patch["from"], None)
+                release = releases.get_release(patch["from"], None, include_sc=False)
                 if release:
                     return createBlob(release["blob"])
                 else:

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -299,7 +299,7 @@ def get_releases(trans):
     return {"releases": sorted(releases, key=lambda r: r["name"])}
 
 
-def get_release(name, trans):
+def get_release(name, trans, include_sc=True):
     def get_base_row():
         row = dbo.releases_json.select(where={"name": name}, transaction=trans)
         if row:
@@ -357,25 +357,26 @@ def get_release(name, trans):
             ensure_path_exists(sc_blob, path)
             set_by_path(sc_blob, path, asset["data"])
 
-    scheduled_row = dbo.releases_json.scheduled_changes.select(where={"base_name": name, "complete": False}, transaction=trans)
-    if sc_exists(name, trans) and (not scheduled_row or scheduled_row[0]["change_type"] != "delete"):
-        sc_blob = deepcopy(base_blob)
+    if include_sc:
+        scheduled_row = dbo.releases_json.scheduled_changes.select(where={"base_name": name, "complete": False}, transaction=trans)
+        if sc_exists(name, trans) and (not scheduled_row or scheduled_row[0]["change_type"] != "delete"):
+            sc_blob = deepcopy(base_blob)
 
-    if scheduled_row:
-        sc_data_versions["."] = scheduled_row[0]["data_version"]
-        if scheduled_row[0]["change_type"] != "delete":
-            # We have to merge rather than update because sc_blob
-            # may contain assets and base data, and updating will fully
-            # overwrite any root level keys from sc_blob with the new
-            # data (rather than doing a deep update/merge).
-            release_merger.merge(sc_blob, scheduled_row[0]["base_data"])
+        if scheduled_row:
+            sc_data_versions["."] = scheduled_row[0]["data_version"]
+            if scheduled_row[0]["change_type"] != "delete":
+                # We have to merge rather than update because sc_blob
+                # may contain assets and base data, and updating will fully
+                # overwrite any root level keys from sc_blob with the new
+                # data (rather than doing a deep update/merge).
+                release_merger.merge(sc_blob, scheduled_row[0]["base_data"])
 
-    for scheduled_asset in dbo.release_assets.scheduled_changes.select(where={"base_name": name, "complete": False}, transaction=trans):
-        path = scheduled_asset["base_path"].split(".")[1:]
-        set_by_path(sc_data_versions, path, scheduled_asset["data_version"])
-        if scheduled_asset["change_type"] != "delete":
-            ensure_path_exists(sc_blob, path)
-            set_by_path(sc_blob, path, scheduled_asset["base_data"])
+        for scheduled_asset in dbo.release_assets.scheduled_changes.select(where={"base_name": name, "complete": False}, transaction=trans):
+            path = scheduled_asset["base_path"].split(".")[1:]
+            set_by_path(sc_data_versions, path, scheduled_asset["data_version"])
+            if scheduled_asset["change_type"] != "delete":
+                ensure_path_exists(sc_blob, path)
+                set_by_path(sc_blob, path, scheduled_asset["base_data"])
 
     if base_blob or sc_blob:
         return {"blob": base_blob, "data_versions": data_versions, "sc_blob": sc_blob, "sc_data_versions": sc_data_versions}

--- a/src/auslib/web/public/client.py
+++ b/src/auslib/web/public/client.py
@@ -173,7 +173,7 @@ def get_update_blob(transaction, **url):
                 # if we have a SuperBlob of systemaddons, we process the response products and
                 # concatenate their inner XMLs
                 product_query = query.copy()
-                release_row = releases.get_release(blob_name, transaction)
+                release_row = releases.get_release(blob_name, transaction, include_sc=False)
                 response_release = None
                 if release_row:
                     product_query["product"] = releases.get_product(blob_name, transaction)


### PR DESCRIPTION
I think this will fix #1337 based on some local analysis. I still want to do some verification with query logging enabled on stage before I feel confident, though.