### PR TITLE
uwsgi/public.ini: enable-threads

### DIFF
--- a/uwsgi/public.ini
+++ b/uwsgi/public.ini
@@ -1,3 +1,4 @@
 [uwsgi]
 http = :$(PORT)
 wsgi-file = /app/uwsgi/public.wsgi
+enable-threads = true


### PR DESCRIPTION
Enable threads to remedy:

```
/usr/local/lib/python3.8/site-packages/sentry_sdk/_compat.py:85: Warning: We detected the use of uwsgi with disabled threads.  This will cause issues with the transport you are trying to use.  Please enable threading for uwsgi.  (Add the "enable-threads" flag).
```