### PR TITLE
Fix logic for showing/hiding scheduled changes with a channel filter applied

### DIFF
--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -5,7 +5,7 @@ const ruleMatchesChannel = (rule, channel) => {
   // similarly, if the rule or scheduled rule has a wildcard, and the
   // selected channel does not match either, this rule does not match
   const ruleChannel = rule.channel;
-  const ruleScheduledChangeChannel =
+  const scChannel =
     rule.scheduledChange && rule.scheduledChange.channel;
   let ruleChannelMatches = false;
   let scChannelMatches = false;
@@ -18,23 +18,29 @@ const ruleMatchesChannel = (rule, channel) => {
     } else if (channel.startsWith(ruleChannel.split('*')[0])) {
       ruleChannelMatches = true;
     }
-  }
+  } else {
+      ruleChannelMatches = true;
+    }
 
-  if (ruleScheduledChangeChannel) {
-    if (ruleScheduledChangeChannel.indexOf('*') === -1) {
-      if (ruleScheduledChangeChannel === channel) {
+  if (scChannel) {
+    if (scChannel.indexOf('*') === -1) {
+      if (scChannel === channel) {
         scChannelMatches = true;
       }
-    } else if (channel.startsWith(ruleScheduledChangeChannel.split('*')[0])) {
+    } else if (channel.startsWith(scChannel.split('*')[0])) {
       scChannelMatches = true;
     }
+  } else {
+      if (rule.scheduledChange) {
+      scChannelMatches = true;
+      }
   }
 
-  if (!ruleChannelMatches && !scChannelMatches) {
-    return false;
+  if (ruleChannelMatches || scChannelMatches) {
+    return true;
   }
 
-  return true;
+  return false;
 };
 
 export {

--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -6,12 +6,13 @@ const ruleMatchesChannel = (rule, channel) => {
     r && r.includes('*') && c.startsWith(r.split('*')[0]);
   const ruleChannelMatches =
     // empty or absent channel matches anything
-    // however, a rule could also be non-existent (if a scheduled change is an insert)
+    // however, a rule could also be non-existent
+    // (if a scheduled change is an insert)
     // in this case, channel will be undefined, and we should _never_
     // match on that, otherwise non-existent rules would show up
     // on all filters.
     rule.channel === null ||
-    rule.channel === "" ||
+    rule.channel === '' ||
     rule.channel === channel ||
     matchesGlob(rule.channel, channel);
   // if a scheduled change does not exist at all
@@ -19,7 +20,7 @@ const ruleMatchesChannel = (rule, channel) => {
   // without scheduled changes will always match any filter
   const scChannelMatches = rule.scheduledChange
     ? rule.scheduledChange.channel === null ||
-      rule.scheduledChange.channel === "" ||
+      rule.scheduledChange.channel === '' ||
       rule.scheduledChange.channel === channel ||
       matchesGlob(rule.scheduledChange.channel, channel)
     : false;

--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -1,0 +1,43 @@
+const ruleMatchesChannel = (rule, channel) => {
+  // if neither the rule nor the scheduled rule's channel is an exact
+  // match for the filter (after stripping away a possible wildcard)
+  // this rule does not match
+  // similarly, if the rule or scheduled rule has a wildcard, and the
+  // selected channel does not match either, this rule does not match
+  const ruleChannel = rule.channel;
+  const ruleScheduledChangeChannel =
+    rule.scheduledChange && rule.scheduledChange.channel;
+  let ruleChannelMatches = false;
+  let scChannelMatches = false;
+
+  if (ruleChannel) {
+    if (ruleChannel.indexOf('*') === -1) {
+      if (ruleChannel === channel) {
+        ruleChannelMatches = true;
+      }
+    } else if (channel.startsWith(ruleChannel.split('*')[0])) {
+      ruleChannelMatches = true;
+    }
+  }
+
+  if (ruleScheduledChangeChannel) {
+    if (ruleScheduledChangeChannel.indexOf('*') === -1) {
+      if (ruleScheduledChangeChannel === channel) {
+        scChannelMatches = true;
+      }
+    } else if (channel.startsWith(ruleScheduledChangeChannel.split('*')[0])) {
+      scChannelMatches = true;
+    }
+  }
+
+  if (!ruleChannelMatches && !scChannelMatches) {
+    return false;
+  }
+
+  return true;
+};
+
+export {
+  // eslint-disable-next-line import/prefer-default-export
+  ruleMatchesChannel,
+};

--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -25,11 +25,7 @@ const ruleMatchesChannel = (rule, channel) => {
       matchesGlob(rule.scheduledChange.channel, channel)
     : false;
 
-  if (ruleChannelMatches || scChannelMatches) {
-    return true;
-  }
-
-  return false;
+  return ruleChannelMatches || scChannelMatches;
 };
 
 export {

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -68,6 +68,7 @@ import { withUser } from '../../../utils/AuthContext';
 import remToPx from '../../../utils/remToPx';
 import elementsHeight from '../../../utils/elementsHeight';
 import Snackbar from '../../../components/Snackbar';
+import { ruleMatchesChannel } from '../../../utils/rules';
 
 const ALL = 'all';
 const useStyles = makeStyles(theme => ({
@@ -452,48 +453,13 @@ function ListRules(props) {
       const [productFilter, channelFilter] = productChannelQueries;
       const ruleProduct =
         rule.product || (rule.scheduledChange && rule.scheduledChange.product);
-      const ruleScheduledChangeChannel =
-        rule.scheduledChange && rule.scheduledChange.channel;
-      const ruleChannel = rule.channel;
 
       if (ruleProduct !== productFilter) {
         return false;
       }
 
-      if (channelFilter) {
-        // if neither the rule nor the scheduled rule's channel is an exact
-        // match for the filter (after stripping away a possible wildcard)
-        // this rule does not match
-        // similarly, if the rule or scheduled rule has a wildcard, and the
-        // selected channel does not match either, this rule does not match
-        let ruleChannelMatches = false;
-        let scChannelMatches = false;
-
-        if (ruleChannel) {
-          if (ruleChannel.indexOf('*') === -1) {
-            if (ruleChannel === channelFilter) {
-              ruleChannelMatches = true;
-            }
-          } else if (channelFilter.startsWith(ruleChannel.split('*')[0])) {
-            ruleChannelMatches = true;
-          }
-        }
-
-        if (ruleScheduledChangeChannel) {
-          if (ruleScheduledChangeChannel.indexOf('*') === -1) {
-            if (ruleScheduledChangeChannel === channelFilter) {
-              scChannelMatches = true;
-            }
-          } else if (
-            channelFilter.startsWith(ruleScheduledChangeChannel.split('*')[0])
-          ) {
-            scChannelMatches = true;
-          }
-        }
-
-        if (!ruleChannelMatches && !scChannelMatches) {
-          return false;
-        }
+      if (channelFilter && !ruleMatchesChannel(rule, channelFilter)) {
+        return false;
       }
 
       return true;

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -454,28 +454,44 @@ function ListRules(props) {
         rule.product || (rule.scheduledChange && rule.scheduledChange.product);
       const ruleScheduledChangeChannel =
         rule.scheduledChange && rule.scheduledChange.channel;
-      let ruleChannel;
+      const ruleChannel = rule.channel;
 
       if (ruleProduct !== productFilter) {
         return false;
       }
 
-      if (ruleScheduledChangeChannel) {
-        if (ruleScheduledChangeChannel.includes('*')) {
-          ruleChannel = rule.channel && ruleScheduledChangeChannel;
-        } else {
-          ruleChannel = ruleScheduledChangeChannel && rule.channel;
-        }
-      } else {
-        ruleChannel = rule.channel;
-      }
-
       if (channelFilter) {
-        if (ruleChannel.indexOf('*') === -1) {
-          if (ruleChannel !== channelFilter) {
-            return false;
+        // if neither the rule nor the scheduled rule's channel is an exact
+        // match for the filter (after stripping away a possible wildcard)
+        // this rule does not match
+        // similarly, if the rule or scheduled rule has a wildcard, and the
+        // selected channel does not match either, this rule does not match
+        let ruleChannelMatches = false;
+        let scChannelMatches = false;
+
+        if (ruleChannel) {
+          if (ruleChannel.indexOf('*') === -1) {
+            if (ruleChannel === channelFilter) {
+              ruleChannelMatches = true;
+            }
+          } else if (channelFilter.startsWith(ruleChannel.split('*')[0])) {
+            ruleChannelMatches = true;
           }
-        } else if (!channelFilter.startsWith(ruleChannel.split('*')[0])) {
+        }
+
+        if (ruleScheduledChangeChannel) {
+          if (ruleScheduledChangeChannel.indexOf('*') === -1) {
+            if (ruleScheduledChangeChannel === channelFilter) {
+              scChannelMatches = true;
+            }
+          } else if (
+            channelFilter.startsWith(ruleScheduledChangeChannel.split('*')[0])
+          ) {
+            scChannelMatches = true;
+          }
+        }
+
+        if (!ruleChannelMatches && !scChannelMatches) {
           return false;
         }
       }

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -73,14 +73,15 @@ describe('channel matching', () => {
   });
   test('should not match anything when rule is null', () => {
     const result = ruleMatchesChannel(
-        {
-            scheduledChange: {
-                channel: 'nightly',
-            },
+      {
+        scheduledChange: {
+          channel: 'nightly',
         },
-        'beta',
+      },
+      'beta'
     );
-      expect(result).toBeFalsy();
+
+    expect(result).toBeFalsy();
   });
   test('should not match rule substring without a glob', () => {
     const result = ruleMatchesChannel(

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -1,0 +1,104 @@
+import { ruleMatchesChannel } from '../src/utils/rules';
+
+describe('channel matching', () => {
+  test('should match when only current rule matches', () => {
+    const result = ruleMatchesChannel(
+      {
+          channel: "nightly",
+          scheduledChange: null,
+        },
+        "nightly",
+    );
+      expect(result).toBeTruthy();
+  });
+  test('should match when only scheduled change matches', () => {
+    const result = ruleMatchesChannel(
+      {
+          channel: "nightly",
+          scheduledChange: {
+              "channel": "release",
+          }
+        },
+        "release",
+    );
+      expect(result).toBeTruthy();
+  });
+  test('should match when rule is null', () => {
+    const result = ruleMatchesChannel(
+      {
+          channel: null,
+          scheduledChange: {
+              channel: "nightly"
+          },
+        },
+        "nightly",
+    );
+      expect(result).toBeTruthy();
+  });
+  test('should match when rule has glob', () => {
+    const rule = {
+          channel: "nightly*",
+          scheduledChange: null,
+        };
+    const channels = ["nightly", "nightly-cdntest", "nightlytest"]
+    const results = channels.map(c => ruleMatchesChannel(rule, c));
+    expect(results).toEqual(expect.not.arrayContaining([false]));
+  });
+  test('should match when scheduled change has glob', () => {
+      const rule = {
+          channel: "nightly",
+          scheduledChange: {
+              "channel": "beta*",
+          },
+      };
+          const channels = ["beta", "beta-localtest"];
+    const results = channels.map(c => ruleMatchesChannel(rule, c));
+    expect(results).toEqual(expect.not.arrayContaining([false]));
+  });
+  test('should match when rule and scheduled change have null channel', () => {
+    const result = ruleMatchesChannel(
+      {
+          channel: null,
+          scheduledChange: {
+              channel: null,
+          },
+        },
+        "nightly",
+    );
+      expect(result).toBeTruthy();
+  });
+  test('should not match rule substring without a glob', () => {
+    const result = ruleMatchesChannel(
+      {
+          channel: "nightly",
+          scheduledChange: null,
+        },
+        "nightly-cdntest",
+    );
+      expect(result).toBeFalsy();
+  });
+  test('should not match scheduled change substring without a glob', () => {
+    const result = ruleMatchesChannel(
+      {
+          channel: "nightly",
+          scheduledChange: {
+            "channel": "beta",
+          },
+        },
+        "beta-cdntest",
+    );
+      expect(result).toBeFalsy();
+  });
+  test('should not match when rule and scheduled change are a different channel', () => {
+    const result = ruleMatchesChannel(
+      {
+          channel: "nightly",
+          scheduledChange: {
+              "channel": "beta",
+          },
+        },
+        "release",
+    );
+      expect(result).toBeFalsy();
+  });
+});

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -4,101 +4,119 @@ describe('channel matching', () => {
   test('should match when only current rule matches', () => {
     const result = ruleMatchesChannel(
       {
-          channel: "nightly",
-          scheduledChange: null,
-        },
-        "nightly",
+        channel: 'nightly',
+        scheduledChange: null,
+      },
+      'nightly'
     );
-      expect(result).toBeTruthy();
+
+    expect(result).toBeTruthy();
   });
   test('should match when only scheduled change matches', () => {
     const result = ruleMatchesChannel(
       {
-          channel: "nightly",
-          scheduledChange: {
-              "channel": "release",
-          }
+        channel: 'nightly',
+        scheduledChange: {
+          channel: 'release',
         },
-        "release",
+      },
+      'release'
     );
-      expect(result).toBeTruthy();
+
+    expect(result).toBeTruthy();
   });
   test('should match when rule is null', () => {
     const result = ruleMatchesChannel(
       {
-          channel: null,
-          scheduledChange: {
-              channel: "nightly"
-          },
+        scheduledChange: {
+          channel: 'nightly',
         },
-        "nightly",
+      },
+      'nightly'
     );
-      expect(result).toBeTruthy();
+
+    expect(result).toBeTruthy();
   });
   test('should match when rule has glob', () => {
     const rule = {
-          channel: "nightly*",
-          scheduledChange: null,
-        };
-    const channels = ["nightly", "nightly-cdntest", "nightlytest"]
+      channel: 'nightly*',
+      scheduledChange: null,
+    };
+    const channels = ['nightly', 'nightly-cdntest', 'nightlytest'];
     const results = channels.map(c => ruleMatchesChannel(rule, c));
+
     expect(results).toEqual(expect.not.arrayContaining([false]));
   });
   test('should match when scheduled change has glob', () => {
-      const rule = {
-          channel: "nightly",
-          scheduledChange: {
-              "channel": "beta*",
-          },
-      };
-          const channels = ["beta", "beta-localtest"];
+    const rule = {
+      channel: 'nightly',
+      scheduledChange: {
+        channel: 'beta*',
+      },
+    };
+    const channels = ['beta', 'beta-localtest'];
     const results = channels.map(c => ruleMatchesChannel(rule, c));
+
     expect(results).toEqual(expect.not.arrayContaining([false]));
   });
   test('should match when rule and scheduled change have null channel', () => {
     const result = ruleMatchesChannel(
       {
+        scheduledChange: {
           channel: null,
-          scheduledChange: {
-              channel: null,
-          },
         },
-        "nightly",
+      },
+      'nightly'
     );
-      expect(result).toBeTruthy();
+
+    expect(result).toBeTruthy();
+  });
+  test('should not match anything when rule is null', () => {
+    const result = ruleMatchesChannel(
+        {
+            scheduledChange: {
+                channel: 'nightly',
+            },
+        },
+        'beta',
+    );
+      expect(result).toBeFalsy();
   });
   test('should not match rule substring without a glob', () => {
     const result = ruleMatchesChannel(
       {
-          channel: "nightly",
-          scheduledChange: null,
-        },
-        "nightly-cdntest",
+        channel: 'nightly',
+        scheduledChange: null,
+      },
+      'nightly-cdntest'
     );
-      expect(result).toBeFalsy();
+
+    expect(result).toBeFalsy();
   });
   test('should not match scheduled change substring without a glob', () => {
     const result = ruleMatchesChannel(
       {
-          channel: "nightly",
-          scheduledChange: {
-            "channel": "beta",
-          },
+        channel: 'nightly',
+        scheduledChange: {
+          channel: 'beta',
         },
-        "beta-cdntest",
+      },
+      'beta-cdntest'
     );
-      expect(result).toBeFalsy();
+
+    expect(result).toBeFalsy();
   });
   test('should not match when rule and scheduled change are a different channel', () => {
     const result = ruleMatchesChannel(
       {
-          channel: "nightly",
-          scheduledChange: {
-              "channel": "beta",
-          },
+        channel: 'nightly',
+        scheduledChange: {
+          channel: 'beta',
         },
-        "release",
+      },
+      'release'
     );
-      expect(result).toBeFalsy();
+
+    expect(result).toBeFalsy();
   });
 });

--- a/ui/test/simple_test.js
+++ b/ui/test/simple_test.js
@@ -1,5 +1,0 @@
-describe('simple', () => {
-  it('should be sane', () => {
-    expect(false).not.toBe(true);
-  });
-});


### PR DESCRIPTION
@rehandalal discovered a crash in the UI yesterday that's triggered when you have a scheduled insert to the Rules. This is a regression from #1483 where we tried to make some enhancements to make sure scheduled changes were always shown in the right places.

This PR fixes the crash without regressing the new feature. I'm not terribly happy with the code, but I had trouble getting it working in a more compact form.