### PR TITLE
[RELENG-486] Support globbed version matching.

### DIFF
--- a/src/auslib/util/comparison.py
+++ b/src/auslib/util/comparison.py
@@ -14,7 +14,15 @@ def has_operator(value):
     return value.startswith(("<", ">"))
 
 
+def glob_op(value, operand):
+    """Compare a string or StrictVersion against a glob stripped of its `*`.
+    Currently only supported in version_compare."""
+    return value.startswith(operand)
+
+
 def get_op(pattern):
+    if pattern.endswith(".*"):
+        return glob_op, pattern.rstrip("*")
     # only alphanumeric characters means no operator
     if re.match(r"\w+", pattern):
         return operator.eq, pattern
@@ -50,6 +58,23 @@ def version_compare(value, compstr, versionClass=MozillaVersion):
     eg version_compare('1.1', '>1.0') is True
     """
     opfunc, operand = get_op(compstr)
-    value = versionClass(value)
-    operand = versionClass(operand)
+    if opfunc is not glob_op:
+        # `StrictVersion.__str__` drops the final digit if it's a 0. For example,
+        #     str(StrictVersion(80.0.0)) -> "80.0"
+        # This breaks if we want to match 80.0.0 (80.0) against `80.0.*`:
+        #     "80.0".startswith("80.0.") -> False
+        # Similarly, if we strip the final `.` from the glob, e.g.
+        #     "80.0".startswith("80.0") -> True
+        # then 80.10.0 will match 80.1.*:
+        #     "80.10".startswith("80.1") -> True
+        # We can either try to reverse engineer StrictVersion's intelligent
+        # version string manipulation, or just not cast `value` to
+        # `versionClass` if we're using `glob_op`.
+        value = versionClass(value)
+        # The glob operand doesn't match StrictVersion's strict version rules,
+        # whether we strip the `*` from it or not, so casting it as a
+        # `versionClass` will throw an exception unless we create a new
+        # StrictVersion based class that accepts those versions.
+        # Let's do a string comparison in `glob_op` instead.
+        operand = versionClass(operand)
     return opfunc(value, operand)

--- a/src/auslib/util/comparison.py
+++ b/src/auslib/util/comparison.py
@@ -7,11 +7,11 @@ operators = {">=": operator.ge, ">": operator.gt, "<": operator.lt, "<=": operat
 
 
 def strip_operator(value):
-    return value.lstrip("<>=")
+    return value.lstrip("<>=").rstrip("*")
 
 
 def has_operator(value):
-    return value.startswith(("<", ">"))
+    return value.startswith(("<", ">")) or value.endswith(".*")
 
 
 def glob_op(value, operand):

--- a/src/auslib/util/jsonschema_validators.py
+++ b/src/auslib/util/jsonschema_validators.py
@@ -5,7 +5,7 @@ import operator
 import jsonschema
 from jsonschema.compat import str_types
 
-from auslib.util.comparison import get_op, strip_operator
+from auslib.util.comparison import get_op, glob_op, strip_operator
 from auslib.util.versions import MozillaVersion
 
 logger = logging.getLogger(__name__)
@@ -49,7 +49,8 @@ def version_validator(field_value):
                 raise jsonschema.ValidationError(
                     "Invalid input for %s .Relational Operators are not allowed" " when providing a list of versions." % field_value
                 )
-            version = MozillaVersion(operand)
+            if op is not glob_op:
+                version = MozillaVersion(operand)
         except jsonschema.ValidationError:
             raise
         except ValueError:
@@ -57,7 +58,7 @@ def version_validator(field_value):
         except Exception:
             raise jsonschema.ValidationError("Invalid input for %s . No Operator or Match found." % field_value)
         # MozillaVersion doesn't error on empty strings
-        if not hasattr(version, "version"):
+        if not hasattr(version, "version") and op is not glob_op:
             raise jsonschema.ValidationError("Couldn't parse the version for %s. No attribute 'version' was detected." % field_value)
     return True
 

--- a/src/auslib/util/versions.py
+++ b/src/auslib/util/versions.py
@@ -46,7 +46,7 @@ class AncientMozillaVersion(StrictVersion):
 def MozillaVersion(version):
     try:
         if version.count(".") in (1, 2):
-            if int(version[0]) > 4:
+            if int(version.split(".")[0]) > 4:
                 return PostModernMozillaVersion(version)
             else:
                 return ModernMozillaVersion(version)

--- a/tests/admin/views/test_rules.py
+++ b/tests/admin/views/test_rules.py
@@ -270,6 +270,15 @@ class TestRulesAPI_JSON(ViewTest):
         ret = self._post("/rules", data=dict(backgroundRate=31, mapping="c", priority=33, product="Firefox", update_type="minor", channel="nightlyÁ"))
         self.assertEqual(ret.status_code, 400, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
 
+    def testNewRulePostWithGlob(self):
+        ret = self._post(
+            "/rules",
+            # We really only want to use glob versions with SystemAddons, but
+            # we don't seem to have any SystemAddons releases populated?
+            data=dict(backgroundRate=100, mapping="c", priority=33, product="Firefox", update_type="minor", channel="sysaddon-glob", version="88.99.*"),
+        )
+        self.assertEqual(ret.status_code, 400, "Status Code: %d, Data: %s" % (ret.status_code, ret.data))
+
     def testBackgroundRateZero(self):
         ret = self._post("/rules", data=dict(backgroundRate=0, mapping="c", priority=33, product="Firefox", update_type="minor", channel="nightly"))
         rule_id = int(ret.get_data())

--- a/tests/util/test_compare.py
+++ b/tests/util/test_compare.py
@@ -1,0 +1,20 @@
+import pytest
+
+from auslib.util.comparison import version_compare
+
+
+@pytest.mark.parametrize(
+    "version, glob, expected",
+    (
+        ("80.0.0", "80.0.*", True),
+        ("80.0.1", "80.0.*", True),
+        ("800.0.1", "80.0.*", False),
+        ("80.1.90", "80.1.*", True),
+        ("80.10.0", "80.1.*", False),
+        ("80.1.0", "80.*", True),
+        ("80.9.89", "80.*", True),
+        ("89.89.0", "80.*", False),
+    ),
+)
+def test_glob_version(version, glob, expected):
+    assert version_compare(version, glob) is expected

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -738,6 +738,15 @@ class ClientTestBase(ClientTestCommon):
         dbo.rules.t.insert().execute(
             priority=200,
             backgroundRate=100,
+            mapping="superblobaddon-with-multiple-response-blob-glob",
+            update_type="minor",
+            product="superblobaddon-with-multiple-response-blob-glob",
+            version="99.8.*",
+            data_version=1,
+        )
+        dbo.rules.t.insert().execute(
+            priority=200,
+            backgroundRate=100,
             mapping="superblobaddon-with-one-response-blob",
             update_type="minor",
             product="superblobaddon-with-one-response-blob",
@@ -760,6 +769,20 @@ class ClientTestBase(ClientTestCommon):
         dbo.releases.t.insert().execute(
             name="superblobaddon-with-multiple-response-blob",
             product="superblobaddon-with-multiple-response-blob",
+            data_version=1,
+            data=createBlob(
+                """
+{
+    "name": "superblobaddon",
+    "schema_version": 4000,
+    "blobs": ["responseblob-a", "responseblob-b"]
+}
+"""
+            ),
+        )
+        dbo.releases.t.insert().execute(
+            name="superblobaddon-with-multiple-response-blob-glob",
+            product="superblobaddon-with-multiple-response-blob-glob",
             data_version=1,
             data=createBlob(
                 """
@@ -1323,6 +1346,33 @@ class ClientTest(ClientTestBase):
         <addon id="d" URL="http://a.com/c" hashFunction="SHA512" hashValue="50" size="20" version="5"/>
         <addon id="b" URL="http://a.com/b" hashFunction="sha512" hashValue="23" size="27" version="1"/>
     </addons>
+</updates>
+""",
+        )
+
+    def testSuperBlobAddOnMultipleUpdatesGlob(self):
+        # Matches version glob
+        ret = self.client.get("/update/3/superblobaddon-with-multiple-response-blob-glob/99.8.1/1/p/l/a/a/a/a/update.xml")
+        self.assertUpdateEqual(
+            ret,
+            """<?xml version="1.0"?>
+<updates>
+    <addons>
+        <addon id="c" URL="http://a.com/e" hashFunction="SHA512" hashValue="3" size="2" version="1"/>
+        <addon id="d" URL="http://a.com/c" hashFunction="SHA512" hashValue="50" size="20" version="5"/>
+        <addon id="b" URL="http://a.com/b" hashFunction="sha512" hashValue="23" size="27" version="1"/>
+    </addons>
+</updates>
+""",
+        )
+
+    def testSuperBlobAddOnNoUpdatesGlob(self):
+        # Doesn't match version glob
+        ret = self.client.get("/update/3/superblobaddon-with-multiple-response-blob-glob/99.9.0/1/p/l/a/a/a/a/update.xml")
+        self.assertUpdateEqual(
+            ret,
+            """<?xml version="1.0"?>
+<updates>
 </updates>
 """,
         )


### PR DESCRIPTION
In SystemAddons, we want to target specific version ranges, e.g. `80.*`.
Previous to this patch, that meant we needed both a `<80` rule to
prevent sending the same System Addon(s) to previous versions, and a
`<81` rule to target the `80.*` range. This worked while we maintained
SystemAddons rules manually, but will make it difficult to rewrite rules
automatically.

This patch adds support for `version: 80.*` or `version: 80.1.*` type
globs.