### PR TITLE
bug 1694236: rename whitelist -> allowlist; add test for vpn allowlist

### DIFF
--- a/scripts/test-rules.py
+++ b/scripts/test-rules.py
@@ -20,7 +20,7 @@ site.addsitedir(os.path.join(mydir, "..", "vendor/lib/python"))
 
 log = logging.getLogger(__name__)
 
-WHITELISTED_DOMAINS = {
+ALLOWLISTED_DOMAINS = {
     "download.mozilla.org": ("Firefox",),
     "stage-old.mozilla.org": ("Firefox",),
     "ftp.mozilla.org": ("Firefox",),
@@ -103,7 +103,7 @@ def walkSnippets(AUS, testPath):
         testQuery["queryVersion"] = 3
         release, update_type, _ = AUS.evaluateRules(testQuery)
         if release:
-            balrog_snippets = release.createSnippets(testQuery, update_type, WHITELISTED_DOMAINS, SPECIAL_FORCE_HOSTS)
+            balrog_snippets = release.createSnippets(testQuery, update_type, ALLOWLISTED_DOMAINS, SPECIAL_FORCE_HOSTS)
         else:
             balrog_snippets = {"partial": "", "complete": ""}
 
@@ -186,7 +186,7 @@ if __name__ == "__main__":
         AUS = AUS_Class()
         dbo.setDb(dbPath)
         dbo.create()
-        dbo.setDomainWhitelist(WHITELISTED_DOMAINS)
+        dbo.setDomainAllowlist(ALLOWLISTED_DOMAINS)
         populateDB(td)
         if options.dumprules:
             log.info(

--- a/src/auslib/AUS.py
+++ b/src/auslib/AUS.py
@@ -34,14 +34,14 @@ def isSpecialURL(url, specialForceHosts):
     return False
 
 
-def isForbiddenUrl(url, product, whitelistedDomains):
-    if whitelistedDomains is None:
-        whitelistedDomains = []
+def isForbiddenUrl(url, product, allowlistedDomains):
+    if allowlistedDomains is None:
+        allowlistedDomains = []
     domain = urlparse(url)[1]
-    if domain not in whitelistedDomains:
+    if domain not in allowlistedDomains:
         logging.warning("Forbidden domain: %s", domain)
         return True
-    if product not in whitelistedDomains[domain]:
+    if product not in allowlistedDomains[domain]:
         logging.warning("Forbidden domain for product %s: %s", product, domain)
         return True
     return False

--- a/src/auslib/blobs/base.py
+++ b/src/auslib/blobs/base.py
@@ -145,7 +145,7 @@ class Blob(dict):
         logger_name = "{0}.{1}".format(self.__class__.__module__, self.__class__.__name__)
         self.__class__.log = logging.getLogger(logger_name)
 
-    def validate(self, product, whitelistedDomains):
+    def validate(self, product, allowlistedDomains):
         """Raises a BlobValidationError if the blob is invalid."""
         self.log.debug("Validating blob %s" % self)
         validator = jsonschema.Draft4Validator(self.getSchema(), format_checker=jsonschema.draft4_format_checker)
@@ -158,7 +158,7 @@ class Blob(dict):
         if errors:
             raise BlobValidationError("Invalid blob! See 'errors' for details.", errors)
 
-        if self.containsForbiddenDomain(product, whitelistedDomains):
+        if self.containsForbiddenDomain(product, allowlistedDomains):
             raise ValueError("Blob contains forbidden domain(s)")
 
     def getSchema(self):
@@ -183,7 +183,7 @@ class Blob(dict):
         failing open)."""
         return False
 
-    def containsForbiddenDomain(self, product, whitelistedDomains):
+    def containsForbiddenDomain(self, product, allowlistedDomains):
         raise NotImplementedError()
 
     def getReferencedReleases(self):
@@ -212,19 +212,19 @@ class XMLBlob(Blob):
         """
         return None
 
-    def getInnerHeaderXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerHeaderXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         """
         :return: Releases-specific header should be implemented for individual blobs
         """
         raise NotImplementedError()
 
-    def getInnerFooterXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerFooterXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         """
         :return: Releases-specific header should be implemented for individual blobs
         """
         raise NotImplementedError()
 
-    def getInnerXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         raise NotImplementedError()
 
     def getHeaderXML(self):

--- a/src/auslib/blobs/gmp.py
+++ b/src/auslib/blobs/gmp.py
@@ -12,8 +12,8 @@ class GMPBlobV1(XMLBlob):
         if "schema_version" not in self:
             self["schema_version"] = 1000
 
-    def validate(self, product, whitelistedDomains):
-        XMLBlob.validate(self, product, whitelistedDomains)
+    def validate(self, product, allowlistedDomains):
+        XMLBlob.validate(self, product, allowlistedDomains)
         for vendor in self["vendors"]:
             for platform in self["vendors"][vendor].get("platforms", {}).values():
                 if "hashValue" in platform:
@@ -50,16 +50,16 @@ class GMPBlobV1(XMLBlob):
         # of the client to decide whether or not any action needs to be taken.
         return True
 
-    def getInnerHeaderXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerHeaderXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         return "    <addons>"
 
-    def getInnerFooterXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerFooterXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         return "    </addons>"
 
     # Because specialForceHosts is only relevant to our own internal servers,
     # and these type of updates are always served externally, we don't process
     # them in GMP blobs.
-    def getInnerXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         buildTarget = updateQuery["buildTarget"]
 
         vendorXML = []
@@ -68,7 +68,7 @@ class GMPBlobV1(XMLBlob):
             platformData = self.getPlatformData(vendor, buildTarget)
 
             url = platformData["fileUrl"]
-            if isForbiddenUrl(url, updateQuery["product"], whitelistedDomains):
+            if isForbiddenUrl(url, updateQuery["product"], allowlistedDomains):
                 continue
             vendorXML.append(
                 '        <addon id="%s" URL="%s" hashFunction="%s" hashValue="%s" size="%s" version="%s"/>'
@@ -77,12 +77,12 @@ class GMPBlobV1(XMLBlob):
 
         return vendorXML
 
-    def containsForbiddenDomain(self, product, whitelistedDomains):
+    def containsForbiddenDomain(self, product, allowlistedDomains):
         """Returns True if the blob contains any file URLs that contain a
         domain that we're not allowed to serve updates to."""
         for vendor in self.get("vendors", {}).values():
             for platform in vendor.get("platforms", {}).values():
                 if "fileUrl" in platform:
-                    if isForbiddenUrl(platform["fileUrl"], product, whitelistedDomains):
+                    if isForbiddenUrl(platform["fileUrl"], product, allowlistedDomains):
                         return True
         return False

--- a/src/auslib/blobs/guardian.py
+++ b/src/auslib/blobs/guardian.py
@@ -7,9 +7,9 @@ from auslib.blobs.base import GenericBlob
 class GuardianBlob(GenericBlob):
     jsonschema = "guardian.yml"
 
-    def containsForbiddenDomain(self, product, whitelistedDomains):
+    def containsForbiddenDomain(self, product, allowlistedDomains):
         urls = [p["fileUrl"] for p in self["platforms"].values()]
-        return any([isForbiddenUrl(url, product, whitelistedDomains) for url in urls])
+        return any([isForbiddenUrl(url, product, allowlistedDomains) for url in urls])
 
     def shouldServeUpdate(self, updateQuery):
         if updateQuery["buildTarget"] not in self.get("platforms", {}):
@@ -19,13 +19,13 @@ class GuardianBlob(GenericBlob):
 
         return True
 
-    def getResponse(self, updateQuery, whitelistedDomains):
+    def getResponse(self, updateQuery, allowlistedDomains):
         url = self.get("platforms", {}).get(updateQuery["buildTarget"], {}).get("fileUrl")
         hashValue = self.get("platforms", {}).get(updateQuery["buildTarget"], {}).get("hashValue")
         if not url:
             return {}
 
-        if isForbiddenUrl(url, updateQuery["product"], whitelistedDomains):
+        if isForbiddenUrl(url, updateQuery["product"], allowlistedDomains):
             return {}
 
         return {"version": self["version"], "url": url, "required": self["required"], "hashFunction": self["hashFunction"], "hashValue": hashValue}

--- a/src/auslib/blobs/superblob.py
+++ b/src/auslib/blobs/superblob.py
@@ -25,15 +25,15 @@ class SuperBlob(XMLBlob):
         # Since a superblob update will always be returned.
         return True
 
-    def containsForbiddenDomain(self, product, whitelistedDomains):
+    def containsForbiddenDomain(self, product, allowlistedDomains):
         # Since SuperBlobs don't have any URLs
         return False
 
-    def getInnerHeaderXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerHeaderXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         """
         :return: Header specific to GMP and systemaddons superblob
         """
         return "    <addons>"
 
-    def getInnerFooterXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerFooterXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         return "    </addons>"

--- a/src/auslib/blobs/systemaddons.py
+++ b/src/auslib/blobs/systemaddons.py
@@ -37,15 +37,15 @@ class SystemAddonsBlob(XMLBlob):
 
     # If there are are no updates, we have a special response for SystemAddons
     # blobs. We return <updates></updates>, without the addons tags.
-    def hasUpdates(self, updateQuery, whitelistedDomains):
+    def hasUpdates(self, updateQuery, allowlistedDomains):
         buildTarget = updateQuery["buildTarget"]
         for addon in sorted(self.getAddonsForPlatform(buildTarget)):
             # Checking if the addon update is to be served
             platformData = self.getPlatformData(addon, buildTarget)
             url = platformData["fileUrl"]
             # There might be no updates even if we have response products if
-            # they are not served from whitelisted domains
-            if isForbiddenUrl(url, updateQuery["product"], whitelistedDomains):
+            # they are not served from allowlisted domains
+            if isForbiddenUrl(url, updateQuery["product"], allowlistedDomains):
                 continue
             return True
         return False
@@ -53,7 +53,7 @@ class SystemAddonsBlob(XMLBlob):
     # Because specialForceHosts is only relevant to our own internal servers,
     # and these type of updates are always served externally, we don't process
     # them in SystemAddon blobs, similar to GMP.
-    def getInnerXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
+    def getInnerXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
         # In case we have an uninstall blob, we won't have the addons section
         if self.get("addons") is None:
             return []
@@ -65,7 +65,7 @@ class SystemAddonsBlob(XMLBlob):
             platformData = self.getPlatformData(addon, buildTarget)
 
             url = platformData["fileUrl"]
-            if isForbiddenUrl(url, updateQuery["product"], whitelistedDomains):
+            if isForbiddenUrl(url, updateQuery["product"], allowlistedDomains):
                 continue
             addonXML.append(
                 '        <addon id="%s" URL="%s" hashFunction="%s" hashValue="%s" size="%s" version="%s"/>'
@@ -74,26 +74,26 @@ class SystemAddonsBlob(XMLBlob):
 
         return addonXML
 
-    def getInnerHeaderXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
-        if self.get("uninstall", False) or self.hasUpdates(updateQuery, whitelistedDomains):
+    def getInnerHeaderXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
+        if self.get("uninstall", False) or self.hasUpdates(updateQuery, allowlistedDomains):
             return "    <addons>"
         else:
             return ""
 
-    def getInnerFooterXML(self, updateQuery, update_type, whitelistedDomains, specialForceHosts):
-        if self.get("uninstall", False) or self.hasUpdates(updateQuery, whitelistedDomains):
+    def getInnerFooterXML(self, updateQuery, update_type, allowlistedDomains, specialForceHosts):
+        if self.get("uninstall", False) or self.hasUpdates(updateQuery, allowlistedDomains):
             return "    </addons>"
         else:
             return ""
 
-    def containsForbiddenDomain(self, product, whitelistedDomains):
+    def containsForbiddenDomain(self, product, allowlistedDomains):
         """Returns True if the blob contains any file URLs that contain a
         domain that we're not allowed to serve updates to."""
 
         for addon in self.get("addons", {}).values():
             for platform in addon.get("platforms", {}).values():
                 if "fileUrl" in platform:
-                    if isForbiddenUrl(platform["fileUrl"], product, whitelistedDomains):
+                    if isForbiddenUrl(platform["fileUrl"], product, allowlistedDomains):
                         return True
 
         return False

--- a/src/auslib/config.py
+++ b/src/auslib/config.py
@@ -37,17 +37,17 @@ class AUSConfig(object):
     def getDburi(self):
         return self.cfg.get("database", "dburi")
 
-    def getDomainWhitelist(self):
+    def getDomainAllowlist(self):
         # the config should have a format like this
-        # domain_whitelist = download.mozilla.org:Firefox|Fennec|Thunderbird, ftp.mozilla.org:SystemAddons
+        # domain_allowlist = download.mozilla.org:Firefox|Fennec|Thunderbird, ftp.mozilla.org:SystemAddons
         try:
-            whitelist_config = dict()
-            pref = self.cfg.get("site-specific", "domain_whitelist").split(", ")
+            allowlist_config = dict()
+            pref = self.cfg.get("site-specific", "domain_allowlist").split(", ")
             for domain_pref in pref:
                 domain, products = domain_pref.split(":")
                 products = products.split("|")
-                whitelist_config[domain] = tuple(products)
-            return whitelist_config
+                allowlist_config[domain] = tuple(products)
+            return allowlist_config
         except (NoSectionError, NoOptionError):
             return dict()
 

--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -1949,7 +1949,7 @@ class Rules(AUSTable):
         return matchingRules
 
     def getRule(self, id_or_alias, transaction=None):
-        """ Returns the unique rule that matches the give rule_id or alias."""
+        """Returns the unique rule that matches the give rule_id or alias."""
         where = []
         # Figuring out which column to use ahead of times means there's only
         # one potential index for the database to use, which should make
@@ -2014,7 +2014,7 @@ class Rules(AUSTable):
 
 class Releases(AUSTable):
     def __init__(self, db, metadata, dialect, history_buckets, historyClass):
-        self.domainWhitelist = []
+        self.domainAllowlist = []
 
         self.table = Table(
             "releases",
@@ -2083,8 +2083,8 @@ class Releases(AUSTable):
             potential_required_signoffs["rs"] = signoffs_required
         return potential_required_signoffs
 
-    def setDomainWhitelist(self, domainWhitelist):
-        self.domainWhitelist = domainWhitelist
+    def setDomainAllowlist(self, domainAllowlist):
+        self.domainAllowlist = domainAllowlist
 
     def getReleases(self, name=None, product=None, limit=None, transaction=None):
         self.log.debug("Looking for releases with:")
@@ -2204,7 +2204,7 @@ class Releases(AUSTable):
 
         blob = columns["data"]
 
-        blob.validate(columns["product"], self.domainWhitelist)
+        blob.validate(columns["product"], self.domainAllowlist)
         if columns["name"] != blob["name"]:
             raise ValueError("name in database (%s) does not match name in blob (%s)" % (columns["name"], blob["name"]))
 
@@ -2234,7 +2234,7 @@ class Releases(AUSTable):
                     self._proceedIfNotReadOnly(current_release["name"], transaction=transaction)
 
                 if blob:
-                    blob.validate(what.get("product", current_release["product"]), self.domainWhitelist)
+                    blob.validate(what.get("product", current_release["product"]), self.domainAllowlist)
                     name = what.get("name", name)
                     if name != blob["name"]:
                         raise ValueError("name in database (%s) does not match name in blob (%s)" % (name, blob.get("name")))
@@ -2345,7 +2345,7 @@ class Releases(AUSTable):
                 if a not in releaseBlob["platforms"]:
                     releaseBlob["platforms"][a] = {"alias": platform}
 
-        releaseBlob.validate(product, self.domainWhitelist)
+        releaseBlob.validate(product, self.domainAllowlist)
         what = dict(data=releaseBlob)
 
         self.update(where=where, what=what, changed_by=changed_by, old_data_version=old_data_version, transaction=transaction)
@@ -2441,7 +2441,7 @@ class Releases(AUSTable):
 
 class ReleasesJSON(AUSTable):
     def __init__(self, db, metadata, dialect, history_buckets, historyClass):
-        self.domainWhitelist = []
+        self.domainAllowlist = []
 
         self.table = Table(
             "releases_json",
@@ -3117,8 +3117,8 @@ class AUSDatabase(object):
     def setSystemAccounts(self, systemAccounts):
         self.systemAccounts = systemAccounts
 
-    def setDomainWhitelist(self, domainWhitelist):
-        self.releasesTable.setDomainWhitelist(domainWhitelist)
+    def setDomainAllowlist(self, domainAllowlist):
+        self.releasesTable.setDomainAllowlist(domainAllowlist)
 
     def setupChangeMonitors(self, relayhost, port, username, password, to_addr, from_addr, use_tls=False, notify_tables=None):
         bleeter = make_change_notifier(relayhost, port, username, password, to_addr, from_addr, use_tls)

--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -531,7 +531,7 @@ def update_release(name, blob, old_data_versions, when, changed_by, trans):
                 set_by_path(new_data_versions, path, 1)
 
     # Raises if there are errors
-    createBlob(full_blob).validate(current_product, app.config["WHITELISTED_DOMAINS"])
+    createBlob(full_blob).validate(current_product, app.config["ALLOWLISTED_DOMAINS"])
 
     await_coroutines(coros)
 
@@ -563,7 +563,7 @@ def set_release(name, blob, product, old_data_versions, when, changed_by, trans)
         raise ReadOnlyError("Cannot overwrite a Release that is marked as read-only")
 
     # Raises if there are errors
-    createBlob(blob).validate(product or current_product, app.config["WHITELISTED_DOMAINS"])
+    createBlob(blob).validate(product or current_product, app.config["ALLOWLISTED_DOMAINS"])
 
     current_assets = get_assets(name, trans)
     base_blob, new_assets = split_release(blob, blob["schema_version"])

--- a/src/auslib/web/admin/swagger/api.yml
+++ b/src/auslib/web/admin/swagger/api.yml
@@ -1883,7 +1883,7 @@ paths:
                   rule_id: 308
                   update_type: "minor"
                   version: null
-                  whitelist: null
+                  allowlist: null
         '404':
           $ref: '#/responses/resourceNotFound'
         '400':

--- a/src/auslib/web/admin/views/releases.py
+++ b/src/auslib/web/admin/views/releases.py
@@ -397,7 +397,7 @@ class ReleasesAPIView(AdminView):
 
 
 class SingleReleaseColumnView(AdminView):
-    """ /releases/columns/:column"""
+    """/releases/columns/:column"""
 
     def get(self, column):
         releases = dbo.releases.getReleaseInfo()

--- a/src/auslib/web/admin/views/rules.py
+++ b/src/auslib/web/admin/views/rules.py
@@ -82,7 +82,7 @@ class RulesAPIView(AdminView):
 
 
 class SingleRuleView(AdminView):
-    """ /rules/:id"""
+    """/rules/:id"""
 
     # changed_by is available via the requirelogin decorator
     @requirelogin

--- a/src/auslib/web/common/swagger/definitions.yml
+++ b/src/auslib/web/common/swagger/definitions.yml
@@ -437,7 +437,7 @@ definitions:
                 rule_id: 308
                 update_type: "minor"
                 version: null
-                whitelist: null
+                allowlist: null
 
   EmergencyShutOffModel:
     title: Emergency shut off data.

--- a/src/auslib/web/public/client.py
+++ b/src/auslib/web/public/client.py
@@ -203,16 +203,16 @@ def get_update_blob(transaction, **url):
 
         # Appending Header
         # In case of superblob Extracting Header form parent release
-        xml.append(release.getInnerHeaderXML(query, update_type, app.config["WHITELISTED_DOMAINS"], app.config["SPECIAL_FORCE_HOSTS"]))
+        xml.append(release.getInnerHeaderXML(query, update_type, app.config["ALLOWLISTED_DOMAINS"], app.config["SPECIAL_FORCE_HOSTS"]))
         for response_blob in response_blobs:
             xml.extend(
                 response_blob["response_release"].getInnerXML(
-                    response_blob["product_query"], response_blob["response_update_type"], app.config["WHITELISTED_DOMAINS"], app.config["SPECIAL_FORCE_HOSTS"]
+                    response_blob["product_query"], response_blob["response_update_type"], app.config["ALLOWLISTED_DOMAINS"], app.config["SPECIAL_FORCE_HOSTS"]
                 )
             )
         # Appending Footer
         # In case of superblob Extracting Header form parent release
-        xml.append(release.getInnerFooterXML(query, update_type, app.config["WHITELISTED_DOMAINS"], app.config["SPECIAL_FORCE_HOSTS"]))
+        xml.append(release.getInnerFooterXML(query, update_type, app.config["ALLOWLISTED_DOMAINS"], app.config["SPECIAL_FORCE_HOSTS"]))
         xml.append(release.getFooterXML())
         # ensure valid xml by using the right entity for ampersand
         xml = re.sub("&(?!amp;)", "&amp;", "\n".join(xml))

--- a/src/auslib/web/public/json.py
+++ b/src/auslib/web/public/json.py
@@ -19,7 +19,7 @@ def get_update(transaction, **parameters):
 
     headers = get_aus_metadata_headers(eval_metadata)
 
-    response = json.dumps(release.getResponse(parameters, app.config["WHITELISTED_DOMAINS"]))
+    response = json.dumps(release.getResponse(parameters, app.config["ALLOWLISTED_DOMAINS"]))
 
     if app.config.get("AUTOGRAPH_URL"):
         hash_ = make_hash(response)

--- a/src/auslib/web/public/swagger/public_api_spec.yml
+++ b/src/auslib/web/public/swagger/public_api_spec.yml
@@ -221,7 +221,7 @@ paths:
                   rule_id: 308
                   update_type: "minor"
                   version: null
-                  whitelist: null
+                  allowlist: null
         '404':
           $ref: '#/responses/resourceNotFound'
         '400':

--- a/tests/admin/views/base.py
+++ b/tests/admin/views/base.py
@@ -47,7 +47,7 @@ class ViewTest(unittest.TestCase):
         app.config["SECRET_KEY"] = "abc123"
         app.config["DEBUG"] = True
         app.config["WTF_CSRF_ENABLED"] = False
-        app.config["WHITELISTED_DOMAINS"] = {"good.com": ("a", "b", "c", "d")}
+        app.config["ALLOWLISTED_DOMAINS"] = {"good.com": ("a", "b", "c", "d")}
         app.config["VERSION_FILE"] = self.version_file
         app.config["AUTH_DOMAIN"] = "balrog.test.dev"
         app.config["AUTH_AUDIENCE"] = "balrog test"
@@ -72,7 +72,7 @@ class ViewTest(unittest.TestCase):
         # maybe we should mock this only in the tests we care about?
         dbo.releases.history = FakeGCSHistory()
 
-        dbo.setDomainWhitelist({"good.com": ("a", "b", "c", "d")})
+        dbo.setDomainAllowlist({"good.com": ("a", "b", "c", "d")})
         self.metadata.create_all(dbo.engine)
         dbo.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         dbo.permissions.t.insert().execute(permission="permission", username="bob", data_version=1)

--- a/tests/admin/views/conftest.py
+++ b/tests/admin/views/conftest.py
@@ -24,7 +24,7 @@ def api():
     app.config["AUTH_DOMAIN"] = "balrog.test.dev"
     app.config["AUTH_AUDIENCE"] = "balrog test"
     app.config["M2M_ACCOUNT_MAPPING"] = {}
-    app.config["WHITELISTED_DOMAINS"] = {
+    app.config["ALLOWLISTED_DOMAINS"] = {
         "download.mozilla.org": ("Firefox",),
         "archive.mozilla.org": ("Firefox",),
         "cdmdownload.adobe.com": ("CDM",),

--- a/tests/blobs/test_gmp.py
+++ b/tests/blobs/test_gmp.py
@@ -9,7 +9,7 @@ class TestSchema1Blob(unittest.TestCase):
 
     def setUp(self):
         self.specialForceHosts = ["http://a.com"]
-        self.whitelistedDomains = {"a.com": ("gg",), "boring.com": ("gg",)}
+        self.allowlistedDomains = {"a.com": ("gg",), "boring.com": ("gg",)}
         self.blob = GMPBlobV1()
         self.blob.loadJSON(
             """
@@ -63,7 +63,7 @@ class TestSchema1Blob(unittest.TestCase):
 
     def testValidateHashLength(self):
         blob = GMPBlobV1()
-        blob.whitelistedDomains = {"boring.com": ("gg",)}
+        blob.allowlistedDomains = {"boring.com": ("gg",)}
         blob.loadJSON(
             """
 {
@@ -86,7 +86,7 @@ class TestSchema1Blob(unittest.TestCase):
 """
         )
         self.assertRaisesRegex(
-            ValueError, ("The hashValue length is different from the required length of 128 for sha512"), blob.validate, "gg", self.whitelistedDomains
+            ValueError, ("The hashValue length is different from the required length of 128 for sha512"), blob.validate, "gg", self.allowlistedDomains
         )
 
     def testGetVendorsForPlatform(self):
@@ -137,9 +137,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.blob.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = "<addons>"
         expected = [
@@ -169,9 +169,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.blob.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = "<addons>"
         expected = [
@@ -201,9 +201,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.blob.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = "<addons>"
         expected = [
@@ -230,9 +230,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.blob.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = "<addons>"
         expected = [
@@ -262,9 +262,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.blob.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.blob.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.blob.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = "<addons>"
         expected = []
@@ -297,7 +297,7 @@ class TestSchema1Blob(unittest.TestCase):
 }
 """
         )
-        self.assertTrue(blob.containsForbiddenDomain("gg", self.whitelistedDomains))
+        self.assertTrue(blob.containsForbiddenDomain("gg", self.allowlistedDomains))
 
     def testDoesNotContainForbiddenDomain(self):
         blob = GMPBlobV1()
@@ -322,7 +322,7 @@ class TestSchema1Blob(unittest.TestCase):
 }
 """
         )
-        self.assertFalse(blob.containsForbiddenDomain("gg", self.whitelistedDomains))
+        self.assertFalse(blob.containsForbiddenDomain("gg", self.allowlistedDomains))
 
     def testGMPLayoutEmptyVendor(self):
 
@@ -339,7 +339,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        blob.validate("gg", self.whitelistedDomains)
+        blob.validate("gg", self.allowlistedDomains)
 
     def testGMPLayoutNoVendor(self):
 
@@ -355,7 +355,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        self.assertRaises(Exception, blob.validate, "gg", self.whitelistedDomains)
+        self.assertRaises(Exception, blob.validate, "gg", self.allowlistedDomains)
 
     def testGMPLayoutTwoPlatforms(self):
 
@@ -387,7 +387,7 @@ bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcda
     }
     """
         )
-        blob.validate("gg", self.whitelistedDomains)
+        blob.validate("gg", self.allowlistedDomains)
 
     def testGMPLayoutMissingVersion(self):
 
@@ -418,7 +418,7 @@ bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcda
     }
     """
         )
-        self.assertRaises(Exception, blob.validate, "gg", self.whitelistedDomains)
+        self.assertRaises(Exception, blob.validate, "gg", self.allowlistedDomains)
 
     def testGMPLayoutEmptyPlatforms(self):
 
@@ -440,7 +440,7 @@ bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcda
     }
     """
         )
-        blob.validate("gg", self.whitelistedDomains)
+        blob.validate("gg", self.allowlistedDomains)
 
     def testGMPLayoutEmptyPlatformName(self):
 
@@ -470,7 +470,7 @@ bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcda
     }
     """
         )
-        self.assertRaises(Exception, blob.validate, "gg", self.whitelistedDomains)
+        self.assertRaises(Exception, blob.validate, "gg", self.allowlistedDomains)
 
     def testGMPLayoutNoFilesize(self):
 
@@ -501,4 +501,4 @@ bcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcda
     }
     """
         )
-        self.assertRaises(Exception, blob.validate, "gg", self.whitelistedDomains)
+        self.assertRaises(Exception, blob.validate, "gg", self.allowlistedDomains)

--- a/tests/blobs/test_guardian.py
+++ b/tests/blobs/test_guardian.py
@@ -31,9 +31,9 @@ def guardianblob():
     return blob
 
 
-@pytest.mark.parametrize("whitelistedDomains,expected", [({"a.com": ("Guardian",)}, False), ({}, True)])
-def testContainsForbiddenDomain(guardianblob, whitelistedDomains, expected):
-    assert guardianblob.containsForbiddenDomain("Guardian", whitelistedDomains) is expected
+@pytest.mark.parametrize("allowlistedDomains,expected", [({"a.com": ("Guardian",)}, False), ({}, True)])
+def testContainsForbiddenDomain(guardianblob, allowlistedDomains, expected):
+    assert guardianblob.containsForbiddenDomain("Guardian", allowlistedDomains) is expected
 
 
 @pytest.mark.parametrize(
@@ -50,7 +50,7 @@ def testShouldServeUpdateMissingBuildTarget(guardianblob):
 
 
 @pytest.mark.parametrize(
-    "buildTarget,whitelistedDomains,expected",
+    "buildTarget,allowlistedDomains,expected",
     [
         (
             "WINNT_x86_64",
@@ -66,6 +66,6 @@ def testShouldServeUpdateMissingBuildTarget(guardianblob):
         ("WINNT_x86_64", {}, {}),
     ],
 )
-def testGetResponse(guardianblob, buildTarget, whitelistedDomains, expected):
+def testGetResponse(guardianblob, buildTarget, allowlistedDomains, expected):
     updateQuery = {"product": "Guardian", "version": "0.5.0.0", "buildTarget": buildTarget, "channel": "release"}
-    assert guardianblob.getResponse(updateQuery, whitelistedDomains) == expected
+    assert guardianblob.getResponse(updateQuery, allowlistedDomains) == expected

--- a/tests/blobs/test_superblob.py
+++ b/tests/blobs/test_superblob.py
@@ -8,7 +8,7 @@ class TestSchema1Blob(unittest.TestCase):
 
     def setUp(self):
         self.specialForceHosts = ("http://a.com",)
-        self.whitelistedDomains = {"a.com": ("b", "c", "e", "b2g", "response-a", "response-b", "s")}
+        self.allowlistedDomains = {"a.com": ("b", "c", "e", "b2g", "response-a", "response-b", "s")}
         self.superblob_gmp = SuperBlob()
         self.superblob_gmp.loadJSON(
             """
@@ -61,8 +61,8 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        headerXML_gmp = self.superblob_gmp.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        headerXML_addon = self.superblob_addon.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        headerXML_gmp = self.superblob_gmp.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        headerXML_addon = self.superblob_addon.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
 
         expected_header_gmp = "    <addons>"
         expected_header_addon = "    <addons>"
@@ -83,8 +83,8 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        footerXML_gmp = self.superblob_gmp.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        footerXML_addon = self.superblob_addon.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        footerXML_gmp = self.superblob_gmp.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        footerXML_addon = self.superblob_addon.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         expected_footer_gmp = "    </addons>"
         expected_footer_addon = "    </addons>"
         self.assertEqual(footerXML_gmp, expected_footer_gmp)

--- a/tests/blobs/test_systemaddons.py
+++ b/tests/blobs/test_systemaddons.py
@@ -8,7 +8,7 @@ class TestSchema1Blob(unittest.TestCase):
 
     def setUp(self):
         self.specialForceHosts = ["http://a.com"]
-        self.whitelistedDomains = {"a.com": ("gg",), "boring.com": ("gg",)}
+        self.allowlistedDomains = {"a.com": ("gg",), "boring.com": ("gg",)}
         self.blob1 = SystemAddonsBlob()
         self.blob1.loadJSON(
             """
@@ -106,9 +106,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.blob1.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.blob1.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.blob1.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.blob1.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.blob1.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.blob1.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = "    <addons>"
         expected = [
@@ -138,9 +138,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.empty_blob.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.empty_blob.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.empty_blob.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.empty_blob.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.empty_blob.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.empty_blob.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = ""
         expected = []
@@ -163,9 +163,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.blob2.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.blob2.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.blob2.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.blob2.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.blob2.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.blob2.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = "    <addons>"
         expected = []
@@ -189,9 +189,9 @@ class TestSchema1Blob(unittest.TestCase):
             "distVersion": "a",
             "force": 0,
         }
-        returned_header = self.blob3.getInnerHeaderXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned = self.blob3.getInnerXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
-        returned_footer = self.blob3.getInnerFooterXML(updateQuery, "minor", self.whitelistedDomains, self.specialForceHosts)
+        returned_header = self.blob3.getInnerHeaderXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned = self.blob3.getInnerXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
+        returned_footer = self.blob3.getInnerFooterXML(updateQuery, "minor", self.allowlistedDomains, self.specialForceHosts)
         returned = [x.strip() for x in returned]
         expected_header = ""
         expected = []
@@ -225,7 +225,7 @@ class TestSchema1Blob(unittest.TestCase):
 }
 """
         )
-        self.assertTrue(blob.containsForbiddenDomain("gg", self.whitelistedDomains))
+        self.assertTrue(blob.containsForbiddenDomain("gg", self.allowlistedDomains))
 
     def testDoesNotContainForbiddenDomain(self):
         blob = SystemAddonsBlob()
@@ -250,7 +250,7 @@ class TestSchema1Blob(unittest.TestCase):
 }
 """
         )
-        self.assertFalse(blob.containsForbiddenDomain("gg", self.whitelistedDomains))
+        self.assertFalse(blob.containsForbiddenDomain("gg", self.allowlistedDomains))
 
     def testAddonLayoutEmptyAddons(self):
 
@@ -267,7 +267,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        blob.validate("gg", self.whitelistedDomains)
+        blob.validate("gg", self.allowlistedDomains)
 
     def testAddonLayoutWithUninstall(self):
 
@@ -284,7 +284,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        blob.validate("gg", self.whitelistedDomains)
+        blob.validate("gg", self.allowlistedDomains)
 
     def testAddonLayoutNoAddonsNoUninstall(self):
 
@@ -300,7 +300,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        self.assertRaises(Exception, blob.validate, "gg", self.whitelistedDomains)
+        self.assertRaises(Exception, blob.validate, "gg", self.allowlistedDomains)
 
     def testAddonLayoutTwoPlatforms(self):
 
@@ -331,7 +331,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        blob.validate("gg", self.whitelistedDomains)
+        blob.validate("gg", self.allowlistedDomains)
 
     def testAddonLayoutNoVersion(self):
 
@@ -361,7 +361,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        self.assertRaises(Exception, blob.validate, "gg", self.whitelistedDomains)
+        self.assertRaises(Exception, blob.validate, "gg", self.allowlistedDomains)
 
     def testAddonLayoutEmptyPlatforms(self):
 
@@ -383,7 +383,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        blob.validate("gg", self.whitelistedDomains)
+        blob.validate("gg", self.allowlistedDomains)
 
     def testAddonLayoutEmptyPlatformName(self):
 
@@ -412,7 +412,7 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        self.assertRaises(Exception, blob.validate, "gg", self.whitelistedDomains)
+        self.assertRaises(Exception, blob.validate, "gg", self.allowlistedDomains)
 
     def testAddonLayoutNoFilesize(self):
 
@@ -442,4 +442,4 @@ class TestSchema1Blob(unittest.TestCase):
     }
     """
         )
-        self.assertRaises(Exception, blob.validate, "gg", self.whitelistedDomains)
+        self.assertRaises(Exception, blob.validate, "gg", self.allowlistedDomains)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ dburi=sqlite:///:memory:
 logfile=/foo/bar/baz
 
 [site-specific]
-domain_whitelist=a.com:c|d, boring.com:e
+domain_allowlist=a.com:c|d, boring.com:e
 """
             )
         self.cfg = AUSConfig(self.config_file)
@@ -29,6 +29,6 @@ domain_whitelist=a.com:c|d, boring.com:e
         os.close(self.config_fd)
         os.remove(self.config_file)
 
-    def testWhitelistDomains(self):
+    def testAllowlistDomains(self):
         expected = {"a.com": ("c", "d"), "boring.com": ("e",)}
-        self.assertEqual(expected, self.cfg.getDomainWhitelist())
+        self.assertEqual(expected, self.cfg.getDomainAllowlist())

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -121,7 +121,7 @@ class ClientTestBase(ClientTestCommon):
         self.version_fd, self.version_file = mkstemp()
         app.config["DEBUG"] = True
         app.config["SPECIAL_FORCE_HOSTS"] = ("http://a.com", "http://download.mozilla.org")
-        app.config["WHITELISTED_DOMAINS"] = {
+        app.config["ALLOWLISTED_DOMAINS"] = {
             "a.com": ("b", "c", "e", "f", "response-a", "response-b", "s", "responseblob-a", "responseblob-b", "q", "fallback", "distTest"),
             "download.mozilla.org": ("Firefox",),
             "archive.mozilla.org": ("Firefox",),
@@ -140,7 +140,7 @@ class ClientTestBase(ClientTestCommon):
             )
         dbo.setDb("sqlite:///:memory:")
         self.metadata.create_all(dbo.engine)
-        dbo.setDomainWhitelist(app.config["WHITELISTED_DOMAINS"])
+        dbo.setDomainAllowlist(app.config["ALLOWLISTED_DOMAINS"])
         self.client = app.test_client()
         dbo.permissions.t.insert().execute(permission="admin", username="bill", data_version=1)
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping="b", update_type="minor", product="b", data_version=1, alias="moz-releng")
@@ -1132,7 +1132,7 @@ class ClientTest(ClientTestBase):
         ret = self.client.get("/update/6/s/1.0/1/p/l/a/a/SSE2/a/a/update.xml")
         self.assertUpdatesAreEmpty(ret)
 
-    def testGetURLNotInWhitelist(self):
+    def testGetURLNotInAllowlist(self):
         ret = self.client.get("/update/3/d/20.0/1/p/l/a/a/a/a/update.xml")
         self.assertHttpResponse(ret)
         self.assertEqual(minidom.parseString(ret.get_data()).getElementsByTagName("updates")[0].firstChild.nodeValue, "\n    ")
@@ -1615,11 +1615,11 @@ class ClientTestMig64(ClientTestCommon):
     def setUp(self):
         app.config["DEBUG"] = True
         app.config["SPECIAL_FORCE_HOSTS"] = ("http://a.com",)
-        app.config["WHITELISTED_DOMAINS"] = {"a.com": ("a", "b", "c")}
+        app.config["ALLOWLISTED_DOMAINS"] = {"a.com": ("a", "b", "c")}
         dbo.setDb("sqlite:///:memory:")
         self.metadata.create_all(dbo.engine)
         self.client = app.test_client()
-        dbo.setDomainWhitelist({"a.com": ("a", "b", "c")})
+        dbo.setDomainAllowlist({"a.com": ("a", "b", "c")})
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping="a", update_type="minor", product="a", data_version=1)
         dbo.releases.t.insert().execute(
             name="a",
@@ -1787,11 +1787,11 @@ class ClientTestJaws(ClientTestCommon):
     def setUp(self):
         app.config["DEBUG"] = True
         app.config["SPECIAL_FORCE_HOSTS"] = ("http://a.com",)
-        app.config["WHITELISTED_DOMAINS"] = {"a.com": ("a", "b", "c")}
+        app.config["ALLOWLISTED_DOMAINS"] = {"a.com": ("a", "b", "c")}
         dbo.setDb("sqlite:///:memory:")
         self.metadata.create_all(dbo.engine)
         self.client = app.test_client()
-        dbo.setDomainWhitelist({"a.com": ("a", "b", "c")})
+        dbo.setDomainAllowlist({"a.com": ("a", "b", "c")})
         dbo.rules.t.insert().execute(priority=90, backgroundRate=100, mapping="a", update_type="minor", product="a", data_version=1)
         dbo.releases.t.insert().execute(
             name="a",
@@ -2025,7 +2025,7 @@ class ClientTestWithErrorHandlers(ClientTestCommon):
 
     def setUp(self):
         app.config["DEBUG"] = True
-        app.config["WHITELISTED_DOMAINS"] = {"a.com": ("a",)}
+        app.config["ALLOWLISTED_DOMAINS"] = {"a.com": ("a",)}
         dbo.setDb("sqlite:///:memory:")
         self.metadata.create_all(dbo.engine)
         self.client = app.test_client()
@@ -2223,10 +2223,10 @@ class ClientTestCompactXML(ClientTestCommon):
         self.version_fd, self.version_file = mkstemp()
         app.config["DEBUG"] = True
         app.config["SPECIAL_FORCE_HOSTS"] = ("http://a.com",)
-        app.config["WHITELISTED_DOMAINS"] = {"a.com": ("b",)}
+        app.config["ALLOWLISTED_DOMAINS"] = {"a.com": ("b",)}
         dbo.setDb("sqlite:///:memory:")
         self.metadata.create_all(dbo.engine)
-        dbo.setDomainWhitelist({"a.com": ("b",)})
+        dbo.setDomainAllowlist({"a.com": ("b",)})
         self.client = app.test_client()
         dbo.rules.t.insert().execute(
             priority=90, backgroundRate=100, mapping="Firefox-mozilla-central-nightly-latest", update_type="minor", product="b", data_version=1

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -28,7 +28,7 @@ def mock_autograph(monkeypatch):
 
 @pytest.fixture(scope="module")
 def appconfig():
-    app.config["WHITELISTED_DOMAINS"] = {"good.com": ("Guardian",)}
+    app.config["ALLOWLISTED_DOMAINS"] = {"good.com": ("Guardian",)}
 
 
 @pytest.fixture(scope="module")

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -35,6 +35,38 @@ def appconfig():
 def guardian_db(db_schema):
     db_schema.create_all(dbo.engine)
     dbo.releases.t.insert().execute(
+        name="Guardian-Evil-1.0.0.0",
+        product="Guardian",
+        data_version=1,
+        data=createBlob(
+            """
+{
+    "name": "Guardian-Evil-1.0.0.0",
+    "product": "Guardian",
+    "schema_version": 10000,
+    "version": "1.0.0.0",
+    "required": true,
+    "hashFunction": "sha512",
+    "platforms": {
+        "Darwin_x86_64": {
+            "fileUrl": "https://evil.com/1.0.0.0.dmg",
+            "hashValue": "ghijkl"
+        }
+    }
+}
+"""
+        ),
+    )
+    dbo.rules.t.insert().execute(
+        priority=150,
+        backgroundRate=100,
+        mapping="Guardian-Evil-1.0.0.0",
+        update_type="minor",
+        product="Guardian",
+        channel="evilrelease",
+        data_version=1,
+    )
+    dbo.releases.t.insert().execute(
         name="Guardian-0.5.0.0",
         product="Guardian",
         data_version=1,
@@ -176,6 +208,7 @@ def client():
         ("0.6.0.0", "WINNT_x86_64", "beta", 404, {}),
         # This shouldn't match because the rule on the alpha channel contains fields not used by this type of update query.
         ("0.6.0.0", "WINNT_x86_64", "alpha", 404, {}),
+        ("0.6.0.0", "Darwin_x86_64", "evilrelease", 200, {}),
     ],
 )
 def testGuardianResponse(client, version, buildTarget, channel, code, response):

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -18,7 +18,7 @@ STAGING = bool(int(os.environ.get("STAGING", 0)))
 LOCALDEV = bool(int(os.environ.get("LOCALDEV", 0)))
 
 SYSTEM_ACCOUNTS = ["balrogagent", "balrog-ffxbld", "balrog-tbirdbld", "seabld"]
-DOMAIN_WHITELIST = {
+DOMAIN_ALLOWLIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
     "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
     "download.cdn.mozilla.net": ("Firefox", "Fennec"),
@@ -32,7 +32,7 @@ DOMAIN_WHITELIST = {
 }
 if STAGING or LOCALDEV:
     SYSTEM_ACCOUNTS.extend(["balrog-stage-ffxbld", "balrog-stage-tbirdbld"])
-    DOMAIN_WHITELIST.update(
+    DOMAIN_ALLOWLIST.update(
         {
             "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
             "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
@@ -152,8 +152,8 @@ if os.environ.get("NOTIFY_TO_ADDR"):
         use_tls,
     )
 dbo.setSystemAccounts(SYSTEM_ACCOUNTS)
-dbo.setDomainWhitelist(DOMAIN_WHITELIST)
-application.config["WHITELISTED_DOMAINS"] = DOMAIN_WHITELIST
+dbo.setDomainAllowlist(DOMAIN_ALLOWLIST)
+application.config["ALLOWLISTED_DOMAINS"] = DOMAIN_ALLOWLIST
 application.config["PAGE_TITLE"] = "Balrog Administration"
 application.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
 

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -11,7 +11,7 @@ STAGING = bool(int(os.environ.get("STAGING", 0)))
 LOCALDEV = bool(int(os.environ.get("LOCALDEV", 0)))
 
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
-DOMAIN_WHITELIST = {
+DOMAIN_ALLOWLIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
     "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
     "download.cdn.mozilla.net": ("Firefox", "Fennec"),
@@ -24,7 +24,7 @@ DOMAIN_WHITELIST = {
     "vpn.mozilla.org": ("FirefoxVPN", "Guardian"),
 }
 if STAGING or LOCALDEV:
-    DOMAIN_WHITELIST.update(
+    DOMAIN_ALLOWLIST.update(
         {
             "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
             "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
@@ -76,8 +76,8 @@ cache.make_cache("rules", 500, 30)
 cache.make_cache("updates_disabled", 100, 60)
 
 dbo.setDb(os.environ["DBURI"])
-dbo.setDomainWhitelist(DOMAIN_WHITELIST)
-application.config["WHITELISTED_DOMAINS"] = DOMAIN_WHITELIST
+dbo.setDomainAllowlist(DOMAIN_ALLOWLIST)
+application.config["ALLOWLISTED_DOMAINS"] = DOMAIN_ALLOWLIST
 application.config["SPECIAL_FORCE_HOSTS"] = SPECIAL_FORCE_HOSTS
 # version.json is created when the Docker image is built, and contains details
 # about the current code (version number, commit hash), but doesn't exist in


### PR DESCRIPTION
The rename was done with sed, and sanity checked by hand + through tests. Notably, there's still a few `whitelist` references in schema migration code and tests that cannot be changed.