### PR TITLE
Allow FirefoxVPN to be served from archive.mozilla.org

### DIFF
--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -20,7 +20,7 @@ LOCALDEV = bool(int(os.environ.get("LOCALDEV", 0)))
 SYSTEM_ACCOUNTS = ["balrogagent", "balrog-ffxbld", "balrog-tbirdbld", "seabld"]
 DOMAIN_ALLOWLIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
-    "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
+    "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird", "FirefoxVPN"),
     "download.cdn.mozilla.net": ("Firefox", "Fennec"),
     "ciscobinary.openh264.org": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -13,7 +13,7 @@ LOCALDEV = bool(int(os.environ.get("LOCALDEV", 0)))
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
 DOMAIN_ALLOWLIST = {
     "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
-    "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
+    "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird", "FirefoxVPN"),
     "download.cdn.mozilla.net": ("Firefox", "Fennec"),
     "ciscobinary.openh264.org": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),


### PR DESCRIPTION
We're moving away from publishing these on their own domain in https://bugzilla.mozilla.org/show_bug.cgi?id=1723049. We'll be updating old links in Balrog, but we need to update this first.