### PR TITLE
Force an older version of virtualenv when installing tox for backend …

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -86,7 +86,7 @@ tasks:
                   git clone ${repo_url} balrog &&
                   cd balrog &&
                   git checkout ${head_sha} &&
-                  pip install tox &&
+                  pip install tox 'virtualenv<20.8.0' &&
                   tox
               features:
                 taskclusterProxy: true


### PR DESCRIPTION
…tests

virtualenv 20.8.0 embeds setuptools 58, which has backwards-incompatible
changes that break Tempita (which we depend on via sqlalchemy-migrate).