### PR TITLE
Remove uses of /csrf_token endpoint in client and agent

### DIFF
--- a/agent/src/balrogagent/client.py
+++ b/agent/src/balrogagent/client.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import time
 
 import aiohttp
@@ -49,20 +48,7 @@ async def request(api_root, path, auth0_secrets, method="GET", data={}, headers=
     access_token = await _get_auth0_token(auth0_secrets, loop)
     headers["Authorization"] = "Bearer {}".format(access_token)
 
-    # Aiohttp does not allow cookie from urls that using IP address instead dns name,
-    # so if for any reason agent needs point to IP address, the envvar "ALLOW_COOKIE_FROM_IP_URL"
-    # should be set. (https://aiohttp.readthedocs.io/en/stable/client_advanced.html#cookie-safety)
-    cookie_jar = aiohttp.CookieJar(unsafe=os.environ.get("ALLOW_COOKIE_FROM_IP_URL", False))
-
-    async with aiohttp.ClientSession(loop=loop, cookie_jar=cookie_jar) as client:
-        # Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1471109
-        # In our deployed environments, the Agent doesn't connect to admin over
-        # https, which means it won't send back the session token by default,
-        # which breaks csrf token validation. Changing the cookies to insecure
-        # will let them be sent back, but it's a horrible back.
-        for c in client.cookie_jar:
-            c["secure"] = False
-
+    async with aiohttp.ClientSession(loop=loop) as client:
         logging.debug("Sending %s request to %s", method, url)
         async with client.request(method, url, data=json.dumps(data), headers=headers) as resp:
             # Raises on 400 code or higher, we can assume things are good if we make it past this.

--- a/agent/src/balrogagent/client.py
+++ b/agent/src/balrogagent/client.py
@@ -46,8 +46,6 @@ def get_url(api_root, path):
 async def request(api_root, path, auth0_secrets, method="GET", data={}, headers=default_headers, loop=None):
     headers = headers.copy()
     url = get_url(api_root, path)
-    csrf_url = get_url(api_root, "/csrf_token")
-    data = data.copy()
     access_token = await _get_auth0_token(auth0_secrets, loop)
     headers["Authorization"] = "Bearer {}".format(access_token)
 
@@ -57,13 +55,6 @@ async def request(api_root, path, auth0_secrets, method="GET", data={}, headers=
     cookie_jar = aiohttp.CookieJar(unsafe=os.environ.get("ALLOW_COOKIE_FROM_IP_URL", False))
 
     async with aiohttp.ClientSession(loop=loop, cookie_jar=cookie_jar) as client:
-        # CSRF tokens are only required for POST/PUT/DELETE.
-        if method not in ("HEAD", "GET"):
-            logging.debug("Sending %s request to %s", "HEAD", csrf_url)
-            async with client.request("HEAD", csrf_url, headers=headers) as resp:
-                resp.raise_for_status()
-                data["csrf_token"] = resp.headers["X-CSRF-Token"]
-
         # Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1471109
         # In our deployed environments, the Agent doesn't connect to admin over
         # https, which means it won't send back the session token by default,

--- a/agent/tests/disabled_client.py
+++ b/agent/tests/disabled_client.py
@@ -11,35 +11,17 @@ class fake_request:
     def __init__(self, response_body, response_code):
         self.response_body = response_body
         self.response_code = response_code
-        self.csrf_resp = None
         self.request_data = None
 
     async def __call__(self, method, url, loop=None, data={}, **kwargs):
-        if url.endswith("csrf_token"):
-            self.csrf_resp = aiohttp.client.ClientResponse(
-                "HEAD",
-                URL("http://balrog.fake/api/csrf_token"),
-                writer=None,
-                continue100=None,
-                timer=None,
-                request_info=None,
-                auto_decompress=None,
-                traces=None,
-                loop=loop,
-                session=None,
-            )
-            self.csrf_resp.headers = {"X-CSRF-Token": "foo"}
-            self.csrf_resp.status = 200
-            return self.csrf_resp
-        else:
-            self.request_data = data
-            resp = aiohttp.client.ClientResponse(
-                method, URL(url), writer=None, continue100=None, timer=None, request_info=None, auto_decompress=None, traces=None, loop=loop, session=None
-            )
-            resp.headers = {"Content-Type": "application/json"}
-            resp._body = bytes(json.dumps(self.response_body), "utf-8")
-            resp.status = self.response_code
-            return resp
+        self.request_data = data
+        resp = aiohttp.client.ClientResponse(
+            method, URL(url), writer=None, continue100=None, timer=None, request_info=None, auto_decompress=None, traces=None, loop=loop, session=None
+        )
+        resp.headers = {"Content-Type": "application/json"}
+        resp._body = bytes(json.dumps(self.response_body), "utf-8")
+        resp.status = self.response_code
+        return resp
 
 
 class TestBalrogClient(asynctest.TestCase):
@@ -53,8 +35,6 @@ class TestBalrogClient(asynctest.TestCase):
         }
         with asynctest.patch("aiohttp.request", fake_request(mocked_resp, 200)) as r:
             resp = await client.request("http://balrog.fake", "/api/scheduled_changes", loop=self.loop)
-            # GET requests shouldn't retrieve a CSRF token
-            self.assertEqual(r.csrf_resp, None)
             self.assertEqual(json.loads(r.request_data), {})
             self.assertEqual(mocked_resp, await resp.json())
 
@@ -62,6 +42,5 @@ class TestBalrogClient(asynctest.TestCase):
         mocked_resp = {"new_data_version": 2}
         with asynctest.patch("aiohttp.request", fake_request(mocked_resp, 200)) as r:
             resp = await client.request("http://balrog.fake", "/api/scheduled_changes/1", method="POST", data={"when": 987654321}, loop=self.loop)
-            self.assertEqual(r.csrf_resp.headers, {"X-CSRF-Token": "foo"})
-            self.assertEqual(json.loads(r.request_data), {"csrf_token": "foo", "when": 987654321})
+            self.assertEqual(json.loads(r.request_data), {"when": 987654321})
             self.assertEqual(mocked_resp, await resp.json())

--- a/client/setup.py
+++ b/client/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="balrogclient",
-    version="1.3",
+    version="1.4",
     description="Balrog Admin API Client",
     author="Mozilla Release Engineers",
     author_email="release+python@mozilla.com",

--- a/client/src/balrogclient/__init__.py
+++ b/client/src/balrogclient/__init__.py
@@ -1,3 +1,3 @@
-from balrogclient.api import Release, ReleaseState, Rule, ScheduledRuleChange, SingleLocale, balrog_request, get_balrog_session, is_csrf_token_expired
+from balrogclient.api import Release, ReleaseState, Rule, ScheduledRuleChange, SingleLocale, balrog_request, get_balrog_session
 
-__all__ = ["is_csrf_token_expired", "SingleLocale", "Release", "ReleaseState", "Rule", "ScheduledRuleChange", "get_balrog_session", "balrog_request"]
+__all__ = ["SingleLocale", "Release", "ReleaseState", "Rule", "ScheduledRuleChange", "get_balrog_session", "balrog_request"]


### PR DESCRIPTION
Part 1 of #1308 