### PR TITLE
Update isort options

### DIFF
--- a/agent/tox.ini
+++ b/agent/tox.ini
@@ -43,7 +43,7 @@ parallel_show_output = true
 skip_install = true
 commands =
     black --diff --check {toxinidir}
-    isort --check -df {toxinidir}
+    isort --check --diff {toxinidir}
     flake8 {toxinidir}
     pip-compile-multi verify
 # Doesn't work without a .git directory

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -43,7 +43,7 @@ deps =
     isort
 commands =
     black --diff --check {toxinidir}
-    isort --check -df {toxinidir}
+    isort --check --diff {toxinidir}
     flake8 {toxinidir}
 # Doesn't work without a .git directory
 #    check-manifest -v {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands = coveralls
 skip_install = true
 commands =
     black --diff --check scripts src tests uwsgi
-    isort --check -df scripts src tests uwsgi
+    isort --check --diff scripts src tests uwsgi
     flake8 scripts src tests uwsgi
     pip-compile-multi verify
     check-manifest -v {toxinidir}


### PR DESCRIPTION
Some command line options were deprecated in 5.0.0: https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html

This updates our `tox.ini`s to get rid of the warnings.