### PR TITLE
Use Tempita wheel to bypass its setup.py

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -86,7 +86,7 @@ tasks:
                   git clone ${repo_url} balrog &&
                   cd balrog &&
                   git checkout ${head_sha} &&
-                  pip install tox 'virtualenv<20.8.0' &&
+                  pip install tox &&
                   tox
               features:
                 taskclusterProxy: true

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -619,7 +619,8 @@ swagger-spec-validator==2.7.3 \
 #   -r requirements/base.in
 #   spec-synthase
 tempita==0.5.2 \
-    --hash=sha256:cacecf0baa674d356641f1d406b8bff1d756d739c46b869a54de515d08e6fc9c
+    --hash=sha256:cacecf0baa674d356641f1d406b8bff1d756d739c46b869a54de515d08e6fc9c \
+    --hash=sha256:f4554840cb59c6b4a5df4fad27eea4e3cb47ca7089bfeefb5890ff1bb8af2117
 # via sqlalchemy-migrate
 typing-extensions==3.7.4.3 \
     --hash=sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918 \


### PR DESCRIPTION
In #2221 we forced an old virtualenv version because new setuptools (which it bundles) is incompatible with `use_2to3` in tempita's `setup.py`. It turns out a tempita wheel was added to pypi recently, so we can use that instead to bypass the incompatibility, and stop pinning virtualenv.