### PR TITLE
Add Pinebuild to the public endpoint's domain allowlist

### DIFF
--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -26,8 +26,8 @@ DOMAIN_ALLOWLIST = {
 if STAGING or LOCALDEV:
     DOMAIN_ALLOWLIST.update(
         {
-            "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
-            "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
+            "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild"),
+            "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild"),
             "stage.guardian.nonprod.cloudops.mozgcp.net": ("FirefoxVPN", "Guardian"),
             "stage-vpn.guardian.nonprod.cloudops.mozgcp.net": ("FirefoxVPN", "Guardian"),
         }

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -12,8 +12,8 @@ LOCALDEV = bool(int(os.environ.get("LOCALDEV", 0)))
 
 SPECIAL_FORCE_HOSTS = ["http://download.mozilla.org"]
 DOMAIN_ALLOWLIST = {
-    "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird"),
-    "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird", "FirefoxVPN"),
+    "download.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird", "Pinebuild"),
+    "archive.mozilla.org": ("Firefox", "Fennec", "Devedition", "Thunderbird", "FirefoxVPN", "Pinebuild"),
     "download.cdn.mozilla.net": ("Firefox", "Fennec"),
     "ciscobinary.openh264.org": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),


### PR DESCRIPTION
We had previously added it to the admin endpoint, but missed public.