### PR TITLE
change cadence to weekly and ignore patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,12 @@ updates:
 - package-ecosystem: npm
   directory: "/ui"
   schedule:
-    interval: daily
+    interval: "weekly"
+    day: "monday"
   open-pull-requests-limit: 50
   ignore:
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]
   - dependency-name: "@date-io/date-fns"
     versions:
     - "> 1.3.13"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,19 @@ updates:
 - package-ecosystem: pip
   directory: "/agent/requirements"
   schedule:
-    interval: daily
+    interval: "weekly"
   open-pull-requests-limit: 50
+  ignore:
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]
 - package-ecosystem: pip
   directory: "/requirements"
   schedule:
-    interval: daily
+    interval: "weekly"
   open-pull-requests-limit: 50
+  ignore:
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]
 - package-ecosystem: npm
   directory: "/ui"
   schedule:


### PR DESCRIPTION
I only changed this to ignore patches for JS dependencies for now (it won't ignore security patches). We could also extend this to [minor releases](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore) too. Once I verify it works, I'll make this change to shipit also.

I held off on making changes to the python dependencies so we can figure out a better process for dealing with them. If we're going to continue using`pip-compile multi` instead of merging python depndabot prs, I think we should remove the python entries from this config file and automate it (I like ahal's idea to create a github action to automate that). Thoughts?