### PR TITLE
Fix queries for `Rules.getPotentialRequiredSignoffs` and `Releases.is…

### DIFF
--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -1817,7 +1817,7 @@ class Rules(AUSTable):
                 break
             cond.append(row["product"])
         else:  # nobreak
-            where = [self.product.in_(tuple(cond))]
+            where = [self.db.productRequiredSignoffs.product.in_(tuple(cond))]
 
         q = self.db.productRequiredSignoffs.select(where=where, transaction=transaction)
 
@@ -2368,8 +2368,8 @@ class Releases(AUSTable):
             return False
 
     def isMappedTo(self, name, transaction=None):
-        mapping_count = self.count(where=[self.db.rules.mapping == name], transaction=transaction)
-        fallbackMapping_count = self.count(where=[self.db.rules.fallbackMapping == name], transaction=transaction)
+        mapping_count = self.db.rules.count(where=[self.db.rules.mapping == name], transaction=transaction)
+        fallbackMapping_count = self.db.rules.count(where=[self.db.rules.fallbackMapping == name], transaction=transaction)
         return mapping_count > 0 or fallbackMapping_count > 0
 
     def delete(self, where, changed_by, old_data_version, transaction=None, dryrun=False, signoffs=None):


### PR DESCRIPTION
…MappedTo`

As pointed out when updating to sqlalchemy 1.4, we were querying a table
but the WHERE clause was only referencing another one.

E.g. `isMappedTo` would execute `SELECT count(?) AS count_1 FROM rules, releases
WHERE rules."fallbackMapping" = ?`, which yields `SELECT statement has a
cartesian product between FROM element(s) "releases" and FROM element "rules".
Apply join condition(s) between each element to resolve.`