### PR TITLE
Fix local dockerfiles

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,5 +1,8 @@
 FROM openresty/openresty:centos
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 # netcat is used to listen to the ports.
 
 RUN yum install -y nmap-ncat

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -13,7 +13,7 @@ MAINTAINER bhearsum@mozilla.com
 # xz-utils is needed to unpack sampled ata
 # git is needed to send coverage reports
 RUN apt-get -q update \
-    && apt-get -q --yes install netcat libpcre3 libpcre3-dev default-libmysqlclient-dev mariadb-client curl gcc xz-utils git \
+    && apt-get -q --yes install g++ netcat libpcre3 libpcre3-dev default-libmysqlclient-dev mariadb-client curl gcc xz-utils git \
     && apt-get clean
 
 WORKDIR /app

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,6 +20,7 @@ exclude agent
 exclude client
 exclude docs
 exclude docker-compose.yml
+exclude docker-compose.arm.yml
 exclude requirements
 exclude scripts
 exclude tests

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,21 @@ Run the following command to create and run the necessary containers:
 
     $ docker-compose up
 
+**Note**
+
+*On ARM (M1) chips*
+
+Make sure you are running a recent version of docker compose:
+::
+
+    $ docker-compose version
+    Docker Compose version v2.2.3
+
+Then, run the following command to create and run the necessary containers:
+::
+
+    $ docker-compose -f docker-compose.yml -f docker-compose.arm.yml up
+
 Once it completes, you should be able to access
 
 - http://localhost:9010 - The public API

--- a/docker-compose.arm.yml
+++ b/docker-compose.arm.yml
@@ -1,0 +1,4 @@
+version: '2.4'
+services:
+  balrogdb:
+    platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,7 @@ services:
 
 
   balrogdb:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Some people have reported problems with the balrogui API proxy not working correctly.
 # This appears to be the same problem reported in https://github.com/docker/compose/issues/2172,
 # and seems to only occur with certain (older) versions of docker-compose.
-version: '2.4'
+version: '2.1'
 services:
   balrogadmin:
     build:
@@ -168,7 +168,6 @@ services:
 
 
   balrogdb:
-    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Some people have reported problems with the balrogui API proxy not working correctly.
 # This appears to be the same problem reported in https://github.com/docker/compose/issues/2172,
 # and seems to only occur with certain (older) versions of docker-compose.
-version: '2.1'
+version: '2.4'
 services:
   balrogadmin:
     build:

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -34,7 +34,7 @@ if STAGING or LOCALDEV:
     SYSTEM_ACCOUNTS.extend(["balrog-stage-ffxbld", "balrog-stage-tbirdbld"])
     DOMAIN_ALLOWLIST.update(
         {
-            "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild"),
+            "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild", "SystemAddons"),
             "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild"),
             "stage.guardian.nonprod.cloudops.mozgcp.net": ("FirefoxVPN", "Guardian"),
             "stage-vpn.guardian.nonprod.cloudops.mozgcp.net": ("FirefoxVPN", "Guardian"),


### PR DESCRIPTION
I ran into a few issues running/building balrog locally. This PR contains my fixes.

* The first issue was a missing `appstream` repo when installing nmap-ncat in the `Dockerfile.nginx` image. This issue is related to CentOS 8 reaching End Of Life at the end of 2021. [The `openresty/openresty:centos` image we are using is based on `centos:8`](https://github.com/openresty/docker-openresty/blob/master/centos/Dockerfile#L5)
* The second issue was a missing C++ compiler in the `python:python:3.8-slim` image we are basing the `Dockerfile.test` image on. This was causing an error when building the `brotli` wheel on `pip install`
* The third issue was caused with the mysql image not supporting ARM based architectures. To build an image based on mysql on a computer with an ARM chip (such as my M1 MacBook) we need to specify the platform we are building the image for. On my machine the resulting image it's run in a AMD64 emulator (with some performance degradation). We could potentially move to a mariadb image as a drop in replacement for mysql. Those images support ARM architectures. [Using a mariadb image is the recommended solution in Docker's docs](https://docs.docker.com/desktop/mac/apple-silicon/#known-issues) (not sure if it truly would be a drop in replacement)