### PR TITLE
Guard against intermittent AttributeError on request.transaction

### DIFF
--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -134,7 +134,7 @@ def unicode(error):
 @app.errorhandler(Exception)
 def ise(error):
     capture_exception(error)
-    log.error("Caught ISE 500 error: %r", error)
+    log.exception("Caught ISE 500 error: %r", error)
     log.debug("Request path is: %s", request.path)
     log.debug("Request environment is: %s", request.environ)
     log.debug("Request headers are: %s", request.headers)

--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -134,7 +134,7 @@ def unicode(error):
 @app.errorhandler(Exception)
 def ise(error):
     capture_exception(error)
-    log.error("Caught ISE 500 error.")
+    log.error("Caught ISE 500 error: %r", error)
     log.debug("Request path is: %s", request.path)
     log.debug("Request environment is: %s", request.environ)
     log.debug("Request headers are: %s", request.headers)

--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -88,7 +88,7 @@ def setup_request():
 
 @app.after_request
 def complete_request(response):
-    if request.full_path.startswith("/v2"):
+    if hasattr(request, "transaction"):
         if response.status_code >= 400:
             request.transaction.rollback()
         else:


### PR DESCRIPTION
Consider, what if flask updates request.full_path between before/after? (I can't find any docs that say it will, or won't!)

Or, what if dbo.begin() raises, in setup_request()?

Otherwise, is it possible that @app.before_request is not always called??