### PR TITLE
Add requests retries to balrogclient

### DIFF
--- a/client/src/balrogclient/api.py
+++ b/client/src/balrogclient/api.py
@@ -71,6 +71,10 @@ class BearerAuth(requests.auth.AuthBase):
 def get_balrog_session(auth0_secrets, session=None):
     if not session:
         session = requests.Session()
+        retry = Retry(total=5, backoff_factor=0.1, status_forcelist=[429, 500, 502, 503, 504])
+        http_adapter = requests.adapters.HTTPAdapter(max_retries=retry)
+        session.mount("https://", http_adapter)
+        session.mount("http://", http_adapter)
 
     access_token = _get_auth0_token(auth0_secrets, session=session)
     session.auth = BearerAuth(access_token)

--- a/client/src/balrogclient/api.py
+++ b/client/src/balrogclient/api.py
@@ -8,6 +8,7 @@ import time
 
 import requests
 import requests.auth
+from requests.packages.urllib3.util.retry import Retry
 
 MAX_LOG_LINE_LENGTH = 10000
 # Refresh the tokens 5 minutes before they expire


### PR DESCRIPTION
In case some failures are temporary, enable balrogclient (used by balrogscript) to retry requests.

https://docs.python-requests.org/en/latest/api/?highlight=max_retries#requests.adapters.HTTPAdapter
https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html
