### PR TITLE
AUSTransaction: don't issue a redundant rollback

### DIFF
--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -202,12 +202,8 @@ class AUSTransaction(object):
                 e = exc_type(exc_value)
                 e.__traceback__ = exc_traceback
                 raise e
-            # Also need to check for exceptions during commit!
-            try:
-                self.commit()
-            except Exception:
-                self.rollback()
-                raise
+            # self.commit will issue a rollback if it raises
+            self.commit()
         finally:
             # Always make sure the connection is closed, bug 740360
             self.close()


### PR DESCRIPTION
When AUSTransaction.commit raises, it rolls back the transaction
already, so no need to do it again in __exit__.