### PR TITLE
add pin.sh

### DIFF
--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -1,0 +1,1 @@
+This directory contains helper scripts to maintain the balrog repo.

--- a/maintenance/pin-helper.sh
+++ b/maintenance/pin-helper.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This runs in docker to pin our requirements files.
+set -e
+SUFFIX=${SUFFIX:-txt}
+if [ $# -gt 0 ]; then
+    EXTRA_PCM_ARGS="$@"
+fi
+
+pip install --upgrade pip
+pip install pip-compile-multi
+
+apt-get update
+
+ARGS="-g base -g docs -g test -g local"
+pip-compile-multi -o "$SUFFIX" $ARGS $EXTRA_PCM_ARGS
+chmod 644 requirements/*.txt

--- a/maintenance/pin.sh
+++ b/maintenance/pin.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# We run this in balrog/. to pin all requirements.
+#
+# Usage: maintenance/pin.sh [<extra-pip-compile-multi-arguments>]
+#
+set -e
+set -x
+
+docker run -t -v $PWD:/src -w /src python:3.9 maintenance/pin-helper.sh $@


### PR DESCRIPTION
Loosely based on the pin.sh in scriptworker-scripts, this version is simpler.

This was inspired by our recent trouble with repoze.lru. It does NOT resolve that issue, but gives us a standard way of pinning and a place to customize pinning in the future.