### PR TITLE
Pass --no-deps to `pip install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 # ... really speeds up building new containers
 COPY requirements/ /app/requirements/
 RUN apt-get install -q --yes gcc && \
-    pip install -r requirements/base.txt && \
+    pip install --no-deps -r requirements/base.txt && \
     apt-get -q --yes remove gcc && \
     apt-get -q --yes autoremove && \
     apt-get clean && \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -21,7 +21,7 @@ WORKDIR /app
 # The general app requirements and packages required to run Tox are installed into the system.
 # We copy them in early to avoid re-installing them unless absolutely necessary.
 COPY requirements/ /app/requirements/
-RUN pip install -r requirements/local.txt
+RUN pip install --no-deps -r requirements/local.txt
 
 COPY src/ /app/src/
 COPY tests/ /app/tests/

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ setenv =
     HYPOTHESIS_STORAGE_DIRECTORY=/tmp
 usedevelop = True
 deps =
+    --no-deps
     -r {toxinidir}/requirements/test.txt
 commands =
     {posargs:py.test -n auto --cov-config=tox.ini --cov-append --cov=auslib --cov-report term-missing tests}


### PR DESCRIPTION
Dependencies are resolved when generating the requirements files, so there's no need to have pip do it again at install time, and this lets us work around a pip bug.

Fixes #2647