### PR TITLE
Ignore errors from apt-get update in push-dockerimage script

### DIFF
--- a/agent/scripts/push-dockerimage.sh
+++ b/agent/scripts/push-dockerimage.sh
@@ -16,7 +16,8 @@ fi
 commit=$(git rev-parse HEAD)
 version=$(cat version.txt)
 
-apt-get update && apt-get -y install jq
+apt-get update || :
+apt-get -y install jq
 
 cat > version.json <<EOF
 {

--- a/scripts/push-dockerimage.sh
+++ b/scripts/push-dockerimage.sh
@@ -19,7 +19,8 @@ fi
 commit=$(git rev-parse HEAD)
 version=$(cat version.txt)
 
-apt-get update && apt-get -y install jq
+apt-get update || :
+apt-get -y install jq
 
 cat > version.json <<EOF
 {


### PR DESCRIPTION
The script currently runs in an environment based on ubuntu 14.04, which seems unable to talk to get.docker.io nowadays (see #2716).