### PR TITLE
Remove test dependencies from push-image task

### DIFF
--- a/taskcluster/ci/push-image/kind.yml
+++ b/taskcluster/ci/push-image/kind.yml
@@ -20,11 +20,6 @@ task-defaults:
         taskcluster-proxy: true
         docker-image: {in-tree: skopeo}
         max-run-time: 3600
-    dependencies:
-          tests-js: ui-tests
-          build-js: ui-build
-          tests-backend: test-backend
-          tests-agent: test-agent
     run-on-tasks-for: [github-release]
     run-on-releases: [v]
     run:


### PR DESCRIPTION
We already run the tests on PR and push to the main branch, so there's not really a need to re-run them on release.  Plus, we don't grant release graphs access to the coveralls secret so they currently fail.

Fixes #2738