### PR TITLE
tests: add a check that we can deal with encoded colon and comma in system capabilities

### DIFF
--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -1115,6 +1115,19 @@ class ClientTest(ClientTestBase):
 """,
         )
 
+    def testVersion6GetWithLessThanEqualToMemoryEncoded(self):
+        ret = self.client.get("/update/6/f/1.0/1/p/l/a/a/ISET%3aSSE3%2cMEM%3a8000/a/a/update.xml")
+        self.assertUpdateEqual(
+            ret,
+            """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="1.0" extensionVersion="1.0" buildID="35">
+        <patch type="complete" URL="http://a.com/f" hashFunction="sha512" hashValue="34" size="33"/>
+    </update>
+</updates>
+""",
+        )
+
     def testVersion6GetWithExactMemory(self):
         ret = self.client.get("/update/6/f/1.0/1/p/l/b/a/ISET:SSE3,MEM:9000/a/a/update.xml")
         self.assertUpdateEqual(
@@ -1128,8 +1141,34 @@ class ClientTest(ClientTestBase):
 """,
         )
 
+    def testVersion6GetWithExactMemoryEncoded(self):
+        ret = self.client.get("/update/6/f/1.0/1/p/l/b/a/ISET%3aSSE3%2cMEM%3a9000/a/a/update.xml")
+        self.assertUpdateEqual(
+            ret,
+            """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="1.0" extensionVersion="1.0" buildID="35">
+        <patch type="complete" URL="http://a.com/f" hashFunction="sha512" hashValue="34" size="33"/>
+    </update>
+</updates>
+""",
+        )
+
     def testVersion6GetWithGreaterThanMemory(self):
         ret = self.client.get("/update/6/f/1.0/1/p/l/c/a/ISET:SSE3,MEM:11000/a/a/update.xml")
+        self.assertUpdateEqual(
+            ret,
+            """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="1.0" extensionVersion="1.0" buildID="35">
+        <patch type="complete" URL="http://a.com/f" hashFunction="sha512" hashValue="34" size="33"/>
+    </update>
+</updates>
+""",
+        )
+
+    def testVersion6GetWithGreaterThanMemoryEncoded(self):
+        ret = self.client.get("/update/6/f/1.0/1/p/l/c/a/ISET%3aSSE3%2cMEM%3a11000/a/a/update.xml")
         self.assertUpdateEqual(
             ret,
             """<?xml version="1.0"?>


### PR DESCRIPTION
[Bug 1620327](https://bugzilla.mozilla.org/show_bug.cgi?id=1620327) wants to encode the update URL properly, so let's make sure it works.

As far as I can tell this doesn't require changes to the application code, because the CGI and wsgi specs say PATH_INFO is not URL-encoded, so we don't have to deal with this at all.

Closes #1225