### PR TITLE
Don't crash when logging an update query without osVersion or buildID

### DIFF
--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -1880,7 +1880,7 @@ class Rules(AUSTable):
                 self.log.debug("%s doesn't match %s", rule["version"], updateQuery["version"])
                 continue
             if not matchBuildID(rule["buildID"], updateQuery.get("buildID", "")):
-                self.log.debug("%s doesn't match %s", rule["buildID"], updateQuery["buildID"])
+                self.log.debug("%s doesn't match %s", rule["buildID"], updateQuery.get("buildID"))
                 continue
             if not matchMemory(rule["memory"], updateQuery.get("memory")):
                 self.log.debug("%s doesn't match %s", rule["memory"], updateQuery.get("memory"))
@@ -1889,7 +1889,7 @@ class Rules(AUSTable):
             # specified in a single rule. They are comma delimited, so we need to
             # break them out and create clauses for each one.
             if not matchSimpleExpression(rule["osVersion"], updateQuery.get("osVersion", "")):
-                self.log.debug("%s doesn't match %s", rule["osVersion"], updateQuery["osVersion"])
+                self.log.debug("%s doesn't match %s", rule["osVersion"], updateQuery.get("osVersion"))
                 continue
             if not matchCsv(rule["instructionSet"], updateQuery.get("instructionSet", ""), substring=False):
                 self.log.debug("%s doesn't match %s", rule["instructionSet"], updateQuery.get("instructionSet"))

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -63,6 +63,17 @@ def guardian_db(db_schema):
         mapping="Guardian-Evil-1.0.0.0",
         update_type="minor",
         product="Guardian",
+        channel="release",
+        osVersion="EvilOS",
+        data_version=1,
+        comment="Bogus rule with osVersion set",
+    )
+    dbo.rules.t.insert().execute(
+        priority=150,
+        backgroundRate=100,
+        mapping="Guardian-Evil-1.0.0.0",
+        update_type="minor",
+        product="Guardian",
         channel="evilrelease",
         data_version=1,
     )


### PR DESCRIPTION
Fixes #2872