### PR TITLE
Remove seemingly-unnecessary urldecoding

### DIFF
--- a/src/auslib/web/public/client.py
+++ b/src/auslib/web/public/client.py
@@ -12,12 +12,6 @@ from auslib.global_state import dbo
 from auslib.services import releases
 from auslib.web.public.helpers import AUS, get_aus_metadata_headers, get_content_signature_headers, with_transaction
 
-try:
-    from urllib import unquote
-except ImportError:  # pragma: no cover
-    from urllib.parse import unquote
-
-
 LOG = logging.getLogger(__name__)
 
 
@@ -110,7 +104,6 @@ def getQueryFromURL(url):
     if "systemCapabilities" in query:
         query.update(getSystemCapabilities(url["systemCapabilities"]))
         del query["systemCapabilities"]
-    query["osVersion"] = unquote(query["osVersion"])
     ua = request.headers.get("User-Agent")
     query["headerArchitecture"] = getHeaderArchitecture(query["buildTarget"], ua)
     force = query.get("force")


### PR DESCRIPTION
I added this a Very Long Time Ago in https://github.com/mozilla-releng/balrog/commit/adb45b60b2b9b31e0a765ad3f2dd4c8f943adc45. I don't see anything in there nor the bug it references that suggests it was needed, nor do any tests fail if it is removed. There's no data in this field that _should_ be urlencoded, and even if there was, decoding is already handled by Flask/Werkzeug...so we should be able to safely remove this.