### PR TITLE
Update Dockerfile.test - fix netcat installation

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -13,7 +13,7 @@ MAINTAINER jcristau@mozilla.com
 # xz-utils is needed to unpack sampled ata
 # git is needed to send coverage reports
 RUN apt-get -q update \
-    && apt-get -q --yes install g++ netcat libpcre3 libpcre3-dev default-libmysqlclient-dev mariadb-client curl gcc xz-utils git \
+    && apt-get -q --yes install g++ netcat-traditional libpcre3 libpcre3-dev default-libmysqlclient-dev mariadb-client curl gcc xz-utils git \
     && apt-get clean
 
 WORKDIR /app


### PR DESCRIPTION
Looks like netcat is provided by two different packages:
```
#0 2.852 Package netcat is a virtual package provided by:
#0 2.852   netcat-openbsd 1.219-1
#0 2.852   netcat-traditional 1.10-47
#0 2.852
#0 2.859 E: Package 'netcat' has no installation candidate
```