### PR TITLE
RuleCard: Remove textEllipses class from OS secondary text

### DIFF
--- a/ui/src/components/RuleCard/index.jsx
+++ b/ui/src/components/RuleCard/index.jsx
@@ -565,9 +565,6 @@ function RuleCard({
                         component: 'div',
                         className: classes.primaryText,
                       }}
-                      secondaryTypographyProps={{
-                        className: classes.textEllipsis,
-                      }}
                       primary={
                         <Fragment>
                           OS Version


### PR DESCRIPTION
## This PR fixes issue #2943 

We can see the complete List of OS Versions          |
:-------------------------:|
![ruleCard](https://github.com/mozilla-releng/balrog/assets/60618877/c3634d34-9da3-4422-8e55-37edc9a163e6) | 

### Context
We have styling specified for `textEllipses` class that hides the overflow and shows ellipses (...) instead, to be used in the scenarios when the text is longer than the container.
A `textEllipses` class can be used wherever we need this behaviour. 

### Changes Made
Since it is preferable to see the full OS version, 
- `textEllipses` class has been removed for OS version specifically.
