### PR TITLE
refact(RuleCard): show all OS versions at once

### DIFF
--- a/ui/src/components/RuleCard/index.jsx
+++ b/ui/src/components/RuleCard/index.jsx
@@ -557,29 +557,7 @@ function RuleCard({
                     />
                   </ListItem>
                 )}
-                {rule.osVersion && (
-                  <ListItem className={classes.listItem}>
-                    <ListItemText
-                      title={rule.osVersion.split(',').join('\n')}
-                      primaryTypographyProps={{
-                        component: 'div',
-                        className: classes.primaryText,
-                      }}
-                      primary={
-                        <Fragment>
-                          OS Version
-                          {diffedProperties.includes('osVersion') &&
-                            rule.scheduledChange.change_type === 'update' && (
-                              <span
-                                className={classes.propertyWithScheduledChange}
-                              />
-                            )}
-                        </Fragment>
-                      }
-                      secondary={rule.osVersion}
-                    />
-                  </ListItem>
-                )}
+
                 {rule.instructionSet && (
                   <ListItem className={classes.listItem}>
                     <ListItemText
@@ -687,6 +665,33 @@ function RuleCard({
                         </Fragment>
                       }
                       secondary={rule.headerArchitecture}
+                    />
+                  </ListItem>
+                )}
+              </List>
+            </Grid>
+            <Grid xs={12}>
+              <List>
+                {rule.osVersion && (
+                  <ListItem className={classes.listItem}>
+                    <ListItemText
+                      title={rule.osVersion.split(',').join('\n')}
+                      primaryTypographyProps={{
+                        component: 'div',
+                        className: classes.primaryText,
+                      }}
+                      primary={
+                        <Fragment>
+                          OS Version
+                          {diffedProperties.includes('osVersion') &&
+                            rule.scheduledChange.change_type === 'update' && (
+                              <span
+                                className={classes.propertyWithScheduledChange}
+                              />
+                            )}
+                        </Fragment>
+                      }
+                      secondary={rule.osVersion}
                     />
                   </ListItem>
                 )}


### PR DESCRIPTION
## This PR fixes #2943 

Now we can see all OS versions:

![Screenshot from 2023-10-06 18-05-15](https://github.com/mozilla-releng/balrog/assets/103337221/7cbeec98-66aa-416b-96ff-364476662ad3)

![Screenshot from 2023-10-09 09-15-03](https://github.com/mozilla-releng/balrog/assets/103337221/26ff0224-2d3f-43fa-8563-547e21a9fd52)


The RuleCard component is based on the material UI grid system, elements inside it are set in percentages, so they're always fluid and sized relative to their parent element.

### Changes made:

- Change the `osVesrion` listItem into a gridItem and give it the full width of its parent (`xs=12`) so osVesrion has enough space to be seen