### PR TITLE
Use /bin/bash to call the run.sh entrypoint

### DIFF
--- a/scripts/initdb_and_run.sh
+++ b/scripts/initdb_and_run.sh
@@ -23,4 +23,4 @@ fi
 python scripts/manage-db.py -d mysql://balrogadmin:balrogadmin@$DB_HOST/balrog upgrade
 
 # run the command passed from docker
-/app/scripts/run.sh $@
+/bin/bash /app/scripts/run.sh $@


### PR DESCRIPTION
This might be causing issues on windows where the run script's executable bits are not set.