### PR TITLE
Fixed-error-in-console-about-duplicate-component-keys

### DIFF
--- a/ui/src/components/AutoCompleteText/index.jsx
+++ b/ui/src/components/AutoCompleteText/index.jsx
@@ -128,7 +128,7 @@ function AutoCompleteText({
     return (
       <MenuItem
         {...itemProps}
-        key={suggestion}
+        key={index}
         selected={isHighlighted}
         component="div"
         className={classNames({ [classes.selectedText]: isSelected })}>


### PR DESCRIPTION
Just fixed the following error of duplicate keys among the lists of the AutoCompleteText component :
![encountered_two_children](https://github.com/mozilla-releng/balrog/assets/72272749/cc989b89-5ba3-4feb-9432-c1325652f9c5)
