### PR TITLE
Dont prompt for signoff with irrelevant roles

### DIFF
--- a/ui/src/components/RuleCard/index.jsx
+++ b/ui/src/components/RuleCard/index.jsx
@@ -158,6 +158,7 @@ function RuleCard({
   user,
   readOnly,
   actionLoading,
+  canUserSign,
   // We don't actually use these, but we need to avoid passing them onto
   // `Card` like the rest of the props.
   onAuthorize: _,
@@ -823,14 +824,14 @@ function RuleCard({
             (user && user.email in rule.scheduledChange.signoffs ? (
               <Button
                 color="secondary"
-                disabled={!user || actionLoading}
+                disabled={!canUserSign || !user || actionLoading}
                 onClick={onRevoke}>
                 Revoke Signoff
               </Button>
             ) : (
               <Button
                 color="secondary"
-                disabled={!user || actionLoading}
+                disabled={!canUserSign || !user || actionLoading}
                 onClick={onSignoff}>
                 Signoff
               </Button>

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -432,6 +432,7 @@ function ListRules(props) {
       fetchRoles(username).then(userInfo => {
         const roleList =
           (userInfo.data && Object.keys(userInfo.data.data.roles)) || [];
+
         setRoles(roleList);
 
         if (roleList.length === 0) {
@@ -647,7 +648,8 @@ function ListRules(props) {
     const requiredSignoffRoles = Object.keys(rule.required_signoffs);
     let tempRequiredRolesFromUser = [];
 
-    for (let i in requiredSignoffRoles) {
+    // eslint-disable-next-line no-restricted-syntax,guard-for-in
+    for (const i in requiredSignoffRoles) {
       tempRequiredRolesFromUser = tempRequiredRolesFromUser.concat(
         roles.filter(eachUserRole => {
           return eachUserRole === requiredSignoffRoles[i];
@@ -1217,11 +1219,14 @@ function ListRules(props) {
   const Row = ({ index, style }) => {
     const rule = filteredRulesWithScheduledChanges[index];
     const isSelected = isRuleSelected(rule);
-    let RS = Object.keys(rule.required_signoffs)
+    const RS = Object.keys(rule.required_signoffs);
+
     // check if any user roles matches any required roles signoff
-    for(let x in roles){
-      for(let y in RS){
-        if(roles[x] === RS[y]){
+    // eslint-disable-next-line no-restricted-syntax,guard-for-in
+    for (const x in roles) {
+      // eslint-disable-next-line no-restricted-syntax,guard-for-in
+      for (const y in RS) {
+        if (roles[x] === RS[y]) {
           // As soon as a match is found, sign in button is enabled
           setCanUserSign(true);
           break;

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -156,6 +156,7 @@ function ListRules(props) {
   ] = useState('');
   const [signoffRole, setSignoffRole] = useState('');
   const [requiredRolesFromUser, setRequiredRolesFromUser] = useState([]);
+  const [canUserSign, setCanUserSign] = useState(false);
   const [drawerState, setDrawerState] = useState({ open: false, item: {} });
   const [drawerReleaseName, setDrawerReleaseName] = useState(null);
   const ruleListRef = useRef(null);
@@ -431,7 +432,6 @@ function ListRules(props) {
       fetchRoles(username).then(userInfo => {
         const roleList =
           (userInfo.data && Object.keys(userInfo.data.data.roles)) || [];
-
         setRoles(roleList);
 
         if (roleList.length === 0) {
@@ -647,8 +647,7 @@ function ListRules(props) {
     const requiredSignoffRoles = Object.keys(rule.required_signoffs);
     let tempRequiredRolesFromUser = [];
 
-    // eslint-disable-next-line no-plusplus
-    for (let i = 0; i < requiredSignoffRoles.length; i++) {
+    for (let i in requiredSignoffRoles) {
       tempRequiredRolesFromUser = tempRequiredRolesFromUser.concat(
         roles.filter(eachUserRole => {
           return eachUserRole === requiredSignoffRoles[i];
@@ -1218,6 +1217,17 @@ function ListRules(props) {
   const Row = ({ index, style }) => {
     const rule = filteredRulesWithScheduledChanges[index];
     const isSelected = isRuleSelected(rule);
+    let RS = Object.keys(rule.required_signoffs)
+    // check if any user roles matches any required roles signoff
+    for(let x in roles){
+      for(let y in RS){
+        if(roles[x] === RS[y]){
+          // As soon as a match is found, sign in button is enabled
+          setCanUserSign(true);
+          break;
+        }
+      }
+    }
 
     return (
       <div
@@ -1239,6 +1249,7 @@ function ListRules(props) {
           onRevoke={() => handleRevoke(rule)}
           onViewReleaseClick={handleViewRelease}
           actionLoading={isActionLoading}
+          canUserSign={canUserSign}
         />
       </div>
     );

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -155,6 +155,7 @@ function ListRules(props) {
     setEmergencyShutoffReasonComment,
   ] = useState('');
   const [signoffRole, setSignoffRole] = useState('');
+  const [requiredRolesFromUser, setRequiredRolesFromUser] = useState([])
   const [drawerState, setDrawerState] = useState({ open: false, item: {} });
   const [drawerReleaseName, setDrawerReleaseName] = useState(null);
   const ruleListRef = useRef(null);
@@ -286,8 +287,9 @@ function ListRules(props) {
     props.history.push(`/rules${stringify(qs, { addQueryPrefix: true })}`);
   };
 
-  const handleSignoffRoleChange = ({ target: { value } }) =>
+  const handleSignoffRoleChange = ({ target: { value } }) => 
     setSignoffRole(value);
+  
   const handleSnackbarOpen = ({ message, variant = 'success' }) => {
     setSnackbarState({ message, variant, open: true });
   };
@@ -433,7 +435,7 @@ function ListRules(props) {
 
         setRoles(roleList);
 
-        if (roleList.length > 0) {
+        if (roleList.length === 0) {
           setSignoffRole(roleList[0]);
         }
       });
@@ -592,7 +594,7 @@ function ListRules(props) {
         name="role"
         value={signoffRole}
         onChange={handleSignoffRoleChange}>
-        {roles.map(r => (
+        {requiredRolesFromUser.map(r => (
           <FormControlLabel key={r} value={r} label={r} control={<Radio />} />
         ))}
       </RadioGroup>
@@ -643,6 +645,16 @@ function ListRules(props) {
   };
 
   const handleSignoff = async rule => {
+    const requiredSignoffRoles = Object.keys(rule.required_signoffs)
+    let tempRequiredRolesFromUser =  [];
+    // eslint-disable-next-line no-plusplus
+    for(let i = 0; i < requiredSignoffRoles.length; i++){
+      tempRequiredRolesFromUser = tempRequiredRolesFromUser.concat(roles.filter((eachUserRole)=>{
+        return eachUserRole === requiredSignoffRoles[i]
+      }))
+    }
+    setRequiredRolesFromUser(tempRequiredRolesFromUser);
+
     if (roles.length === 1) {
       const { error, result } = await doSignoff(roles[0], rule);
 

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -155,7 +155,7 @@ function ListRules(props) {
     setEmergencyShutoffReasonComment,
   ] = useState('');
   const [signoffRole, setSignoffRole] = useState('');
-  const [requiredRolesFromUser, setRequiredRolesFromUser] = useState([])
+  const [requiredRolesFromUser, setRequiredRolesFromUser] = useState([]);
   const [drawerState, setDrawerState] = useState({ open: false, item: {} });
   const [drawerReleaseName, setDrawerReleaseName] = useState(null);
   const ruleListRef = useRef(null);
@@ -287,9 +287,8 @@ function ListRules(props) {
     props.history.push(`/rules${stringify(qs, { addQueryPrefix: true })}`);
   };
 
-  const handleSignoffRoleChange = ({ target: { value } }) => 
+  const handleSignoffRoleChange = ({ target: { value } }) =>
     setSignoffRole(value);
-  
   const handleSnackbarOpen = ({ message, variant = 'success' }) => {
     setSnackbarState({ message, variant, open: true });
   };
@@ -645,14 +644,18 @@ function ListRules(props) {
   };
 
   const handleSignoff = async rule => {
-    const requiredSignoffRoles = Object.keys(rule.required_signoffs)
-    let tempRequiredRolesFromUser =  [];
+    const requiredSignoffRoles = Object.keys(rule.required_signoffs);
+    let tempRequiredRolesFromUser = [];
+
     // eslint-disable-next-line no-plusplus
-    for(let i = 0; i < requiredSignoffRoles.length; i++){
-      tempRequiredRolesFromUser = tempRequiredRolesFromUser.concat(roles.filter((eachUserRole)=>{
-        return eachUserRole === requiredSignoffRoles[i]
-      }))
+    for (let i = 0; i < requiredSignoffRoles.length; i++) {
+      tempRequiredRolesFromUser = tempRequiredRolesFromUser.concat(
+        roles.filter(eachUserRole => {
+          return eachUserRole === requiredSignoffRoles[i];
+        })
+      );
     }
+
     setRequiredRolesFromUser(tempRequiredRolesFromUser);
 
     if (roles.length === 1) {


### PR DESCRIPTION
So this is my version of a fix for the issue [don't prompt for signoff with roles that aren't relevant #1145](https://github.com/mozilla-releng/balrog/issues/1145) : 
**NOTE : In all situations, the user has three roles (relman, releng and tb-releng)**
- Where required roles are three : 
![vZGRyrdfMcCueYhppxvNTUie](https://github.com/mozilla-releng/balrog/assets/72272749/b6995a26-b88e-4303-96b3-f0fbca4d7c2d)
- Where required roles are two, user is prompted only those two roles :
![KbgPpGRBLemUUBjrNVWCREQs](https://github.com/mozilla-releng/balrog/assets/72272749/4a447219-7a77-4d87-9a10-8d9044aca56b)
- Where the required role is one, user is prompted that exact role only :
![dbQOJcRBJczdlnkRnUjYOMoz](https://github.com/mozilla-releng/balrog/assets/72272749/8b19e5cf-d663-4cb1-99e5-ffeb9f0817bb)
- and If the user has none of the required roles, the `Signoff` button is diabled for them : 
![HzdvDAiGJSqPwPOjjJKAfhmB](https://github.com/mozilla-releng/balrog/assets/72272749/08ecd1b5-e893-4b89-8d95-dbb07c90dab1)
- and of course, a user can't sign with two roles because they would have to revoke a signoff to be able to make another signoff

