### PR TITLE
allow update of product name when updating a release

### DIFF
--- a/ui/src/views/Releases/Release/index.jsx
+++ b/ui/src/views/Releases/Release/index.jsx
@@ -266,6 +266,7 @@ function Release(props) {
       {!isLoading && (
         <Fragment>
           <TextField
+             disabled={!isNewRelease}
             fullWidth
             label="Release"
             onChange={handleReleaseNameChange}

--- a/ui/src/views/Releases/Release/index.jsx
+++ b/ui/src/views/Releases/Release/index.jsx
@@ -266,7 +266,6 @@ function Release(props) {
       {!isLoading && (
         <Fragment>
           <TextField
-            disabled={!isNewRelease}
             fullWidth
             label="Release"
             onChange={handleReleaseNameChange}


### PR DESCRIPTION
fixes issue #2994 
Allows changing of product name in the form when updating a release.