### PR TITLE
fix: Chips overflowing text field

### DIFF
--- a/ui/src/components/AutoCompleteText/ChipList.jsx
+++ b/ui/src/components/AutoCompleteText/ChipList.jsx
@@ -8,6 +8,10 @@ import CloseIcon from 'mdi-react/CloseIcon';
 const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
+    flexWrap: 'wrap',
+    maxWidth: '120rem',
+    gap: '0.25rem',
+    padding: '0.5rem 0',
   },
   chip: {
     marginRight: theme.spacing(0.5),

--- a/ui/src/components/AutoCompleteText/ChipList.jsx
+++ b/ui/src/components/AutoCompleteText/ChipList.jsx
@@ -9,7 +9,8 @@ const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',
-    maxWidth: '120rem',
+    width: '200rem',
+    flexGrow: '1',
     gap: '0.25rem',
     padding: '0.5rem 0',
   },

--- a/ui/src/components/AutoCompleteText/index.jsx
+++ b/ui/src/components/AutoCompleteText/index.jsx
@@ -34,6 +34,9 @@ const useStyles = makeStyles(theme => ({
   dropdownDisabled: {
     color: theme.palette.action.disabled,
   },
+  endAdornment: {
+    cursor: 'pointer',
+  },
 }));
 
 /**
@@ -184,7 +187,7 @@ function AutoCompleteText({
                 undefined
               ),
               endAdornment: (
-                <div>
+                <div className={classes.endAdornment}>
                   <ChevronDownIcon
                     {...getToggleButtonProps()}
                     className={classNames({

--- a/ui/src/views/Users/ViewUser/index.jsx
+++ b/ui/src/views/Users/ViewUser/index.jsx
@@ -49,6 +49,8 @@ const useStyles = makeStyles(theme => ({
   },
   gridWithIcon: {
     marginTop: theme.spacing(3),
+    display: 'flex',
+    alignItems: 'end',
   },
   gridDelete: {
     display: 'flex',


### PR DESCRIPTION
### This PR fix #1135

#### Changes proposed:
- Add the wrap property to the `chipList` so elements in the `chipList` will wrap instead of overflowing.
- Align all inputs at the same position (`end`)

![Frame 107 (2)](https://github.com/mozilla-releng/balrog/assets/103337221/8487481a-08d3-49e5-87a6-06e042f6542a)

@gabrielBusta @bhearsum 