### PR TITLE
Show required signoffs when updating rules

### DIFF
--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -101,7 +101,6 @@ function Rule({ isNewRule, user, ...props }) {
       : [];
   const [rule, setRule] = useState(initialRule);
   const [releaseNames, setReleaseNames] = useState([]);
-  const [ruleRequiredSignoffs, setRuleRequiredSignoffs] = useState([]);
   const [signoffSummary, setSignoffSummary] = useState('');
   const [products, fetchProducts] = useAction(getProducts);
   const [channels, fetchChannels] = useAction(getChannels);
@@ -126,7 +125,10 @@ function Rule({ isNewRule, user, ...props }) {
   const [updateSCAction, updateSC] = useAction(updateScheduledChange);
   const [deleteSCAction, deleteSC] = useAction(deleteScheduledChange);
   const isLoading =
-    fetchRuleAction.loading || products.loading || channels.loading;
+    fetchRuleAction.loading ||
+    products.loading ||
+    channels.loading ||
+    requiredSignoffs.loading;
   const actionLoading =
     releaseNamesAction.loading ||
     releaseNamesV2Action.loading ||
@@ -398,8 +400,6 @@ function Rule({ isNewRule, user, ...props }) {
             ruleMatchesRequiredSignoff(rule, rs)
           );
 
-          setRuleRequiredSignoffs(curr => curr.concat(matchingRs));
-
           if (!requiredSignoffs.length || !matchingRs.length) {
             setSignoffSummary(' Nobody');
           } else {
@@ -451,14 +451,7 @@ function Rule({ isNewRule, user, ...props }) {
           <div>
             <p className={classes.signoffLabel}>
               Requires Signoff from:
-              <span
-                className={
-                  requiredSignoffs.data &&
-                  ruleRequiredSignoffs.length &&
-                  classes.signoffs
-                }>
-                {signoffSummary}
-              </span>
+              <span className={classes.signoffs}>{signoffSummary}</span>
             </p>
           </div>
           <div className={classes.scheduleDiv}>

--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -382,6 +382,39 @@ function Rule({ isNewRule, user, ...props }) {
     }
   }, [ruleId, scId]);
 
+  useEffect(() => {
+    fetchRequiredSignoffs(OBJECT_NAMES.PRODUCT_REQUIRED_SIGNOFF).then(
+      rsResponse => {
+        const requiredSignoffs = rsResponse.data.data.required_signoffs;
+
+        if (rule.product) {
+          const matchingRs = requiredSignoffs.filter(rs =>
+            ruleMatchesRequiredSignoff(rule, rs)
+          );
+
+          setRuleRequiredSignoffs(curr => curr.concat(matchingRs));
+
+          if (!requiredSignoffs.length || !matchingRs.length) {
+            setSignoffSummary(' None');
+          } else {
+            const rsSummary = matchingRs.reduce((summary, rs, idx) => {
+              const memberStr = rs.signoffs_required > 1 ? 'members' : 'member';
+              const rsStr = `${rs.signoffs_required} ${memberStr} of ${rs.role}`;
+
+              if (idx !== matchingRs.length - 1) {
+                return `${summary}${rsStr}, `;
+              }
+
+              return summary + rsStr;
+            }, ' ');
+
+            setSignoffSummary(rsSummary);
+          }
+        }
+      }
+    );
+  }, [rule.product, rule.channel]);
+
   const today = new Date();
 
   // This will make sure the helperText

--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -85,6 +85,12 @@ const useStyles = makeStyles(theme => ({
   scheduleIcon: {
     marginRight: theme.spacing(3),
   },
+  signoffLabel: {
+    color: 'rgba(0, 0, 0, 0.54)',
+  },
+  signoffs: {
+    color: 'rgba(0, 0, 0, 0.87)',
+  },
 }));
 
 function Rule({ isNewRule, user, ...props }) {
@@ -442,6 +448,19 @@ function Rule({ isNewRule, user, ...props }) {
       {error && <ErrorPanel fixed error={error} />}
       {!isLoading && (
         <Fragment>
+          <div>
+            <p className={classes.signoffLabel}>
+              Required Signoff(s):
+              <span
+                className={
+                  requiredSignoffs.data &&
+                  ruleRequiredSignoffs.length &&
+                  classes.signoffs
+                }>
+                {signoffSummary}
+              </span>
+            </p>
+          </div>
           <div className={classes.scheduleDiv}>
             <DateTimePicker
               todayLabel="ASAP"

--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -450,7 +450,7 @@ function Rule({ isNewRule, user, ...props }) {
         <Fragment>
           <div>
             <p className={classes.signoffLabel}>
-              Required Signoff(s):
+              Required Signoffs:
               <span
                 className={
                   requiredSignoffs.data &&

--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -401,7 +401,7 @@ function Rule({ isNewRule, user, ...props }) {
           setRuleRequiredSignoffs(curr => curr.concat(matchingRs));
 
           if (!requiredSignoffs.length || !matchingRs.length) {
-            setSignoffSummary(' None');
+            setSignoffSummary(' Nobody');
           } else {
             const rsSummary = matchingRs.reduce((summary, rs, idx) => {
               const memberStr = rs.signoffs_required > 1 ? 'members' : 'member';
@@ -450,7 +450,7 @@ function Rule({ isNewRule, user, ...props }) {
         <Fragment>
           <div>
             <p className={classes.signoffLabel}>
-              Required Signoffs:
+              Requires Signoff from:
               <span
                 className={
                   requiredSignoffs.data &&

--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -37,7 +37,10 @@ import {
   EMPTY_MENU_ITEM_CHAR,
   SPLIT_WITH_NEWLINES_AND_COMMA_REGEX,
   RULE_PRODUCT_UNSUPPORTED_PROPERTIES,
+  OBJECT_NAMES,
 } from '../../../utils/constants';
+import { getRequiredSignoffs } from '../../../services/requiredSignoffs';
+import { ruleMatchesRequiredSignoff } from '../../../utils/requiredSignoffs';
 
 const initialRule = {
   alias: '',
@@ -92,8 +95,13 @@ function Rule({ isNewRule, user, ...props }) {
       : [];
   const [rule, setRule] = useState(initialRule);
   const [releaseNames, setReleaseNames] = useState([]);
+  const [ruleRequiredSignoffs, setRuleRequiredSignoffs] = useState([]);
+  const [signoffSummary, setSignoffSummary] = useState('');
   const [products, fetchProducts] = useAction(getProducts);
   const [channels, fetchChannels] = useAction(getChannels);
+  const [requiredSignoffs, fetchRequiredSignoffs] = useAction(
+    getRequiredSignoffs
+  );
   const [releaseNamesAction, fetchReleaseNames] = useAction(getReleaseNames);
   const [releaseNamesV2Action, fetchReleaseNamesV2] = useAction(
     getReleaseNamesV2


### PR DESCRIPTION
Fixes #1147 

1. Fetch the required signoffs and check them against the rule to find matching ones
2. Create an element to display matching signoffs

No signoffs required - greyed out
![Screenshot from 2023-10-20 15-22-37](https://github.com/mozilla-releng/balrog/assets/84005549/b736a82d-bbf9-434c-81d5-53e355eb0d0b)

Signoffs from one role required
![Screenshot from 2023-10-20 15-22-57](https://github.com/mozilla-releng/balrog/assets/84005549/e226b795-87ef-4315-8b6a-941ab956f472)

Signoffs from two roles required
![Screenshot from 2023-10-20 15-23-22](https://github.com/mozilla-releng/balrog/assets/84005549/8724cac3-846c-4777-83e4-846fd79f9f1b)

