### PR TITLE
Prevent scheduling a new rule with a duplicate alias

### DIFF
--- a/src/auslib/web/admin/views/rules.py
+++ b/src/auslib/web/admin/views/rules.py
@@ -239,6 +239,10 @@ class RuleScheduledChangesView(ScheduledChangesView):
                         ext={"exception": "%s cannot be set to null/empty " "when scheduling insertion of a new rule" % field},
                     )
 
+            alias = what.get("alias", None)
+            if alias is not None and dbo.rules.getRule(alias):
+                return problem(400, "Bad Request", "Rule with alias exists.")
+
         if change_type in ["update", "insert"]:
             rule_dict, mapping_values, fallback_mapping_values = process_rule_form(what)
             what = rule_dict


### PR DESCRIPTION
Fixes #2942 

1. Add duplicate alias check at API level to RuleScheduledChangesView

Before insert:
![Screenshot from 2023-10-23 14-45-45](https://github.com/mozilla-releng/balrog/assets/84005549/2b8c7a50-cc26-4ab7-a734-944101e4bca4)

On insert:
![Screenshot from 2023-10-23 14-45-54](https://github.com/mozilla-releng/balrog/assets/84005549/40fb5219-35bb-40ec-8abf-a95590b727f2)