### PR TITLE
Add partial match filter on releases page

### DIFF
--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -140,13 +140,12 @@ function ListReleases(props) {
 
     const values = searchValue.split(' ');
     const regexp = values.reduce(
-      (re, value) => `${re}[A-Za-z0-9](${value})`,
+      (re, value) => `${re}[A-Za-z0-9.-]*(${value})`,
       ''
     );
 
     return releases.filter(release => {
       const regex = RegExp(regexp, 'i');
-
       return regex.test(release.name);
     });
   }, [releases, searchValue]);

--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -146,6 +146,7 @@ function ListReleases(props) {
 
     return releases.filter(release => {
       const regex = RegExp(regexp, 'i');
+
       return regex.test(release.name);
     });
   }, [releases, searchValue]);

--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -138,15 +138,13 @@ function ListReleases(props) {
       return releases;
     }
 
-    const searchTerms = searchValue.toLowerCase().split(' ');
-    const filteredResults = releases.filter(release => {
-      const releaseName = release.name.toLowerCase();
+    const values = searchValue.split(' ');
+    const regexp = values.reduce((re, value) => `${re}[A-Za-z0-9](${value})`, '');
 
-      // Check if all search terms are found in the release name
-      return searchTerms.every(term => releaseName.includes(term));
+    return releases.filter(release => {
+      const regex = RegExp(regexp, 'i');
+      return regex.test(release.name);
     });
-
-    return filteredResults;
   }, [releases, searchValue]);
   const filteredReleasesCount = filteredReleases.length;
   const handleSignoffRoleChange = ({ target: { value } }) =>

--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -139,10 +139,14 @@ function ListReleases(props) {
     }
 
     const values = searchValue.split(' ');
-    const regexp = values.reduce((re, value) => `${re}[A-Za-z0-9](${value})`, '');
+    const regexp = values.reduce(
+      (re, value) => `${re}[A-Za-z0-9](${value})`,
+      ''
+    );
 
     return releases.filter(release => {
       const regex = RegExp(regexp, 'i');
+
       return regex.test(release.name);
     });
   }, [releases, searchValue]);


### PR DESCRIPTION
Fixes #1146 

1. Add filter for partial match on search in releases page

![Screenshot from 2023-10-24 18-57-31](https://github.com/mozilla-releng/balrog/assets/84005549/cad75e76-0cb1-49ad-992c-c19c02aa9a82)