### PR TITLE
Highlight partial matches on releases page

### DIFF
--- a/ui/src/components/ReleaseCard/index.jsx
+++ b/ui/src/components/ReleaseCard/index.jsx
@@ -166,21 +166,29 @@ function ReleaseCard(props) {
     return `/rules${qs}#ruleId=${ruleId}`;
   };
 
-  const highlightMatchedRelease = (highlights) => {
+  const highlightMatchedRelease = highlights => {
     if (highlights) {
-      let highlightedName = [release.name.slice(0, highlights[1][0])];
+      const highlightedName = [release.name.slice(0, highlights[1][0])];
 
-      for (let i = 1; i < highlights.length; i++) {
-        highlightedName.push(<mark>{release.name.slice(...highlights[i])}</mark>);
+      for (let i = 1; i < highlights.length; i += 1) {
+        highlightedName.push(
+          <mark>{release.name.slice(...highlights[i])}</mark>
+        );
+
         if (highlights[i + 1]) {
-          highlightedName.push(release.name.slice(highlights[i][1], highlights[i + 1][0]));
+          highlightedName.push(
+            release.name.slice(highlights[i][1], highlights[i + 1][0])
+          );
         } else {
-          highlightedName.push(release.name.slice(highlights[highlights.length - 1][1]));
+          highlightedName.push(
+            release.name.slice(highlights[highlights.length - 1][1])
+          );
         }
       }
+
       return <Fragment>{highlightedName}</Fragment>;
     }
-  }
+  };
 
   return (
     <Card classes={{ root: classes.root }} {...rest}>
@@ -192,7 +200,9 @@ function ReleaseCard(props) {
             className={classes.releaseName}
             component="h2"
             variant="h6">
-            {rest.releaseHighlight ? highlightMatchedRelease(rest.releaseHighlight) : release.name}{' '}
+            {rest.releaseHighlight
+              ? highlightMatchedRelease(rest.releaseHighlight)
+              : release.name}{' '}
             <a
               href={`#${release.name}`}
               aria-label="Anchor"

--- a/ui/src/components/ReleaseCard/index.jsx
+++ b/ui/src/components/ReleaseCard/index.jsx
@@ -166,6 +166,22 @@ function ReleaseCard(props) {
     return `/rules${qs}#ruleId=${ruleId}`;
   };
 
+  const highlightMatchedRelease = (highlights) => {
+    if (highlights) {
+      let highlightedName = [release.name.slice(0, highlights[1][0])];
+
+      for (let i = 1; i < highlights.length; i++) {
+        highlightedName.push(<mark>{release.name.slice(...highlights[i])}</mark>);
+        if (highlights[i + 1]) {
+          highlightedName.push(release.name.slice(highlights[i][1], highlights[i + 1][0]));
+        } else {
+          highlightedName.push(release.name.slice(highlights[highlights.length - 1][1]));
+        }
+      }
+      return <Fragment>{highlightedName}</Fragment>;
+    }
+  }
+
   return (
     <Card classes={{ root: classes.root }} {...rest}>
       <CardHeader
@@ -176,7 +192,7 @@ function ReleaseCard(props) {
             className={classes.releaseName}
             component="h2"
             variant="h6">
-            {release.name}{' '}
+            {rest.releaseHighlight ? highlightMatchedRelease(rest.releaseHighlight) : release.name}{' '}
             <a
               href={`#${release.name}`}
               aria-label="Anchor"

--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -91,6 +91,7 @@ function ListReleases(props) {
   const [roles, setRoles] = useState([]);
   const [signoffRole, setSignoffRole] = useState('');
   const [drawerState, setDrawerState] = useState({ open: false, item: {} });
+  const [matchHighlight, setMatchHighlight] = useState({});
   const [requiredSignoffsForProduct, setRequiredSignoffsForProduct] = useState(
     null
   );
@@ -146,6 +147,10 @@ function ListReleases(props) {
       const matches = regex.exec(release.name);
       if (matches) {
         const toHighlight = matches.indices
+        setMatchHighlight(prevState => ({
+          ...prevState,
+          [release.name]: toHighlight
+        }));
       }
       return matches;
     });
@@ -704,6 +709,7 @@ function ListReleases(props) {
             [classes.releaseCardSelected]: isSelected,
           })}
           release={release}
+          releaseHighlight={matchHighlight && matchHighlight[release.name]}
           onAccessChange={handleAccessChange}
           onReleaseDelete={handleDelete}
           onViewScheduledChangeDiff={handleViewScheduledChangeDiff}

--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -140,18 +140,24 @@ function ListReleases(props) {
     }
 
     const values = searchValue.split(' ');
-    const regexp = values.reduce((re, value) => `${re}[A-Za-z0-9.-]*(${value})`, '');
+    const regexp = values.reduce(
+      (re, value) => `${re}[A-Za-z0-9.-]*(${value})`,
+      ''
+    );
 
     return releases.filter(release => {
       const regex = new RegExp(regexp, 'dgi');
       const matches = regex.exec(release.name);
+
       if (matches) {
-        const toHighlight = matches.indices
+        const toHighlight = matches.indices;
+
         setMatchHighlight(prevState => ({
           ...prevState,
-          [release.name]: toHighlight
+          [release.name]: toHighlight,
         }));
       }
+
       return matches;
     });
   }, [releases, searchValue]);

--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -139,15 +139,15 @@ function ListReleases(props) {
     }
 
     const values = searchValue.split(' ');
-    const regexp = values.reduce(
-      (re, value) => `${re}[A-Za-z0-9.-]*(${value})`,
-      ''
-    );
+    const regexp = values.reduce((re, value) => `${re}[A-Za-z0-9.-]*(${value})`, '');
 
     return releases.filter(release => {
-      const regex = RegExp(regexp, 'i');
-
-      return regex.test(release.name);
+      const regex = new RegExp(regexp, 'dgi');
+      const matches = regex.exec(release.name);
+      if (matches) {
+        const toHighlight = matches.indices
+      }
+      return matches;
     });
   }, [releases, searchValue]);
   const filteredReleasesCount = filteredReleases.length;


### PR DESCRIPTION
Fixes #3007

1. Highlight partial match results on search in releases page

![Screenshot from 2023-10-24 19-31-36](https://github.com/mozilla-releng/balrog/assets/84005549/672cabb5-16b6-453b-bb70-a7a809362898)