### PR TITLE
Show required signoffs appropriately when updating rules 

### DIFF
--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -396,12 +396,14 @@ function Rule({ isNewRule, user, ...props }) {
     const rs =
       requiredSignoffs.data && requiredSignoffs.data.data.required_signoffs;
 
-    if (rs) {
+    if (!rs || !rule.product) {
+      setSignoffSummary(' Nobody');
+    } else {
       const matchingRs = rs.filter(rso =>
         ruleMatchesRequiredSignoff(rule, rso)
       );
 
-      if (!rule.product || !matchingRs.length) {
+      if (!matchingRs.length) {
         setSignoffSummary(' Nobody');
       } else {
         // Count the number of signoffs required from each role


### PR DESCRIPTION
Fixes #1147 by updating #3025 to apply the following fixes:

1. Fix unneccessary re-fetching of required signoffs by fetching them once on page load
2. Fix unneccessary re-rendering of page when signoff summary updates on channel or product value change
3. Fix signoff summary to show 'Nobody' instead of all signoffs required when no product value
4. Fix multiple renders of same role in signoff summary to only one role summary per role