### PR TITLE
Stop showing scheduled deletions on unrelated channels

### DIFF
--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -22,15 +22,17 @@ const ruleMatchesChannel = (rule, channel) => {
   // we never want scheduled deletions to match any filter
   // because the scheduled change channel on deletions is null
   // and the rule channel is a truthy value that might not equal 'channel'
-  const scChannelMatches = rule.scheduledChange
-    ? (rule.channel &&
-        ruleChannelMatches &&
-        rule.scheduledChange.channel === null) ||
-      (!rule.channel && rule.scheduledChange.channel === null) ||
-      rule.scheduledChange.channel === '' ||
-      rule.scheduledChange.channel === channel ||
-      matchesGlob(rule.scheduledChange.channel, channel)
-    : false;
+  let scChannelMatches = false;
+
+  if (rule.scheduledChange) {
+    if (rule.scheduledChange.change_type !== 'delete') {
+      scChannelMatches =
+        rule.scheduledChange.channel === null ||
+        rule.scheduledChange.channel === '' ||
+        rule.scheduledChange.channel === channel ||
+        matchesGlob(rule.scheduledChange.channel, channel);
+    }
+  }
 
   return ruleChannelMatches || scChannelMatches;
 };

--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -23,7 +23,9 @@ const ruleMatchesChannel = (rule, channel) => {
   // because the scheduled change channel on deletions is null
   // and the rule channel is a truthy value that might not equal 'channel'
   const scChannelMatches = rule.scheduledChange
-    ? (rule.channel && ruleChannelMatches && rule.scheduledChange.channel === null) ||
+    ? (rule.channel &&
+        ruleChannelMatches &&
+        rule.scheduledChange.channel === null) ||
       (!rule.channel && rule.scheduledChange.channel === null) ||
       rule.scheduledChange.channel === '' ||
       rule.scheduledChange.channel === channel ||

--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -19,7 +19,7 @@ const ruleMatchesChannel = (rule, channel) => {
   // we never want this to match, otherwise all rules
   // without scheduled changes will always match any filter
   const scChannelMatches = rule.scheduledChange
-    ? rule.scheduledChange.channel === null ||
+    ? rule.scheduledChange.channel === null && rule.channel === null ||
       rule.scheduledChange.channel === '' ||
       rule.scheduledChange.channel === channel ||
       matchesGlob(rule.scheduledChange.channel, channel)

--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -18,8 +18,12 @@ const ruleMatchesChannel = (rule, channel) => {
   // if a scheduled change does not exist at all
   // we never want this to match, otherwise all rules
   // without scheduled changes will always match any filter
+  // if a scheduled change is a deletion
+  // we never want scheduled deletions to match any filter
+  // because the scheduled change channel on deletions is null
+  // and the rule channel is a truthy value that might not equal 'channel'
   const scChannelMatches = rule.scheduledChange
-    ? rule.scheduledChange.channel === null && rule.channel === null ||
+    ? (rule.channel && ruleChannelMatches && rule.scheduledChange.channel === null) ||
       rule.scheduledChange.channel === '' ||
       rule.scheduledChange.channel === channel ||
       matchesGlob(rule.scheduledChange.channel, channel)

--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -24,6 +24,7 @@ const ruleMatchesChannel = (rule, channel) => {
   // and the rule channel is a truthy value that might not equal 'channel'
   const scChannelMatches = rule.scheduledChange
     ? (rule.channel && ruleChannelMatches && rule.scheduledChange.channel === null) ||
+      (!rule.channel && rule.scheduledChange.channel === null) ||
       rule.scheduledChange.channel === '' ||
       rule.scheduledChange.channel === channel ||
       matchesGlob(rule.scheduledChange.channel, channel)

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -25,7 +25,7 @@ describe('channel matching', () => {
 
     expect(result).toBeTruthy();
   });
-  test('should match when rule is null', () => {
+  test('should match when rule is null and scheduled change matches', () => {
     const result = ruleMatchesChannel(
       {
         scheduledChange: {
@@ -71,7 +71,7 @@ describe('channel matching', () => {
 
     expect(result).toBeTruthy();
   });
-  test('should not match anything when rule is null', () => {
+  test('should not match anything when rule is null and scheduled change is a different channel', () => {
     const result = ruleMatchesChannel(
       {
         scheduledChange: {

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -133,4 +133,17 @@ describe('channel matching', () => {
 
     expect(result).toBeFalsy();
   });
+  test('should not match when rule has a different channel and scheduled change channel is null', () => {
+    const result = ruleMatchesChannel(
+      {
+        channel: 'aurora',
+        scheduledChange: {
+          channel: null,
+        },
+      },
+      'release'
+    );
+
+    expect(result).toBeFalsy();
+  });
 });

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -59,9 +59,22 @@ describe('channel matching', () => {
 
     expect(results).toEqual(expect.not.arrayContaining([false]));
   });
+  test('should match when rule is null and scheduled change has null channel', () => {
+    const result = ruleMatchesChannel(
+      {
+        scheduledChange: {
+          channel: null,
+        },
+      },
+      'nightly'
+    );
+
+    expect(result).toBeTruthy();
+  });
   test('should match when rule and scheduled change have null channel', () => {
     const result = ruleMatchesChannel(
       {
+        channel: null,
         scheduledChange: {
           channel: null,
         },

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -133,11 +133,12 @@ describe('channel matching', () => {
 
     expect(result).toBeFalsy();
   });
-  test('should not match when rule has a different channel and scheduled change channel is null', () => {
+  test('should not match when rule has a different channel and scheduled change type is delete with channel null', () => {
     const result = ruleMatchesChannel(
       {
         channel: 'aurora',
         scheduledChange: {
+          change_type: 'delete',
           channel: null,
         },
       },


### PR DESCRIPTION
Fixes #2312:

1. Modify ruleMatchesChannel function to account for scheduled deletions
2. Rename tests for increased clarity on what is being tested
3. Create tests for scenarios that arose from rewording tests
4. Create tests for scheduled deletions matching