### PR TITLE
Select role in signoff dialog to enable updates

### DIFF
--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -932,7 +932,9 @@ function ListRules(props) {
   };
 
   const handleSignoffEnableUpdates = async () => {
-    setRequiredRoles(Object.keys(filteredRulesWithScheduledChanges[0].required_signoffs))
+    setRequiredRoles(
+      Object.keys(filteredRulesWithScheduledChanges[0].required_signoffs)
+    );
     const [product, channel] = productChannelQueries;
     const esDetails = emergencyShutoffs.find(
       es => es.product === product && es.channel === channel

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -932,6 +932,7 @@ function ListRules(props) {
   };
 
   const handleSignoffEnableUpdates = async () => {
+    setRequiredRoles(Object.keys(filteredRulesWithScheduledChanges[0].required_signoffs))
     const [product, channel] = productChannelQueries;
     const esDetails = emergencyShutoffs.find(
       es => es.product === product && es.channel === channel
@@ -1068,6 +1069,7 @@ function ListRules(props) {
     const dialogStates = {
       delete: deleteDialogBody,
       signoff: signoffDialogBody,
+      signoffEnableUpdates: signoffDialogBody,
       disableUpdates: disableUpdatesBody,
     };
 


### PR DESCRIPTION
Hi @gbrownmozilla ,this PR solves the [ISSUE](https://github.com/mozilla-releng/balrog/issues/2986) you raised. 

You can now select role to signoff , to enable updates : 
 
![chrome_723CyJ6fMj](https://github.com/mozilla-releng/balrog/assets/72272749/a2b4feea-8f0d-440f-ab51-4ef828f7f867)

Don't know how I didn't see this issue all this while.
