### PR TITLE
tests: add sanity checks around `make_hash` calls

### DIFF
--- a/src/auslib/util/autograph.py
+++ b/src/auslib/util/autograph.py
@@ -10,6 +10,7 @@ SIGNATURE_PREFIX = "Content-Signature:\x00"
 
 
 def make_hash(content):
+    assert isinstance(content, str)
     templated = f"{SIGNATURE_PREFIX}{content}".encode("ascii")
     return sha384(templated).digest()
 


### PR DESCRIPTION
Adding some changes that would have caught the regression from #3035.