### PR TITLE
log: avoid crashing when a log entry includes a non-JSON-serializable object

### DIFF
--- a/agent/src/balrogagent/log.py
+++ b/agent/src/balrogagent/log.py
@@ -102,7 +102,7 @@ class JsonLogFormatter(logging.Formatter):
 
         out["Fields"] = fields
 
-        return json.dumps(out)
+        return json.dumps(out, default=str)
 
 
 def safer_format_traceback(exc_typ, exc_val, exc_tb):

--- a/src/auslib/log.py
+++ b/src/auslib/log.py
@@ -135,7 +135,7 @@ class JsonLogFormatter(logging.Formatter):
 
         out["Fields"] = fields
 
-        return json.dumps(out)
+        return json.dumps(out, default=str)
 
 
 def safer_format_traceback(exc_typ, exc_val, exc_tb):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -100,3 +100,18 @@ def test_no_message(caplog):
 
     o = json.loads(stream.getvalue())
     assert "message" not in o["Fields"]
+
+
+def test_not_serializable(caplog):
+    stream = StringIO()
+    configure_logging(stream=stream)
+
+    logging.info("", extra={"type": bytes, "data": b""})
+
+    assert len(caplog.records) == 1
+    r = caplog.records[0]
+
+    assert r.levelno == 20
+
+    o = json.loads(stream.getvalue())
+    assert set(o["Fields"]) == {"type", "data"}


### PR DESCRIPTION
When enabling all debug logging we end up with fairly arbitrary objects in log messages.  Default to the object's `__str__` method in that case.

Note this is fairly arbitrary, I could be convinced to use `repr` instead.  I've seen stuff like `bytes`, `type`, `Response` in extra logging data from our dependencies, which all break with plain `json.dumps`.