### PR TITLE
doc update: bump version after tagging, rather than after prod deploy

### DIFF
--- a/docs/source/infrastructure.rst
+++ b/docs/source/infrastructure.rst
@@ -92,6 +92,8 @@ To get the new code in stage you must create a new Release in Github as follows:
 
 3. `Create a new Release on Github <https://github.com/mozilla-releng/balrog/releases>`_. This create new Docker images tagged with your version, and deploys them to stage. It may take upwards of 30 minutes for the deployment to happen. Deployment notifications will show up in #balrog on Slack.
 
+4. Finally, bump the `in-repo version <https://github.com/mozilla-releng/balrog/blob/main/version.txt>`_ to the next available one to ensure the next push gets a new version.
+
 Once the changes are deployed to stage, you should do some testing to make sure that the new features, fixes, etc. are working properly there. It's a good idea to `watch Sentry for new exceptions <https://sentry.io/organizations/mozilla/projects/>`_ that may show up, and Grafana for any notable changes in the shape of the traffic.
 
 **Important Note!** Only two-part version numbers (like shown above) are supported by our deployment pipeline.
@@ -123,8 +125,6 @@ To push new UI to production you must delete and recreate the "production-ui" ta
   * On https://github.com/mozilla-releng/balrog/releases/tag/production-ui, click "Delete" (this deletes the Github Release).
   * On https://github.com/mozilla-releng/balrog/releases/tag/production-ui, click "Delete" (this deletes the Git tag, even though it's the same URL).
   * On https://github.com/mozilla-releng/balrog/releases/new, create a new `production-ui` Release. This will trigger automation to deploy the new UI.
-
-Finally, bump the `in-repo version <https://github.com/mozilla-releng/balrog/blob/main/version.txt>`_ to the next available one to ensure the next push gets a new version.
 
 ~~~~~~~~~
 Rollbacks


### PR DESCRIPTION
The existing docs suggest the balrog version should be bumped only after the production deployment. With our new Tuesday (staging) / Thursday (production) cadence, that means we go two days with version.txt == the current tag. I think it makes more sense to bump the version immediately after tagging and release creation -- ie, as part of the staging deployment.