### PR TITLE
Fix error in console for out-of-range select value on Rules page

### DIFF
--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -1304,7 +1304,7 @@ function ListRules(props) {
               className={classes.dropdown}
               select
               label={`Product${productChannelSeparator}Channel`}
-              value={productChannelFilter}
+              value={productChannelOptions.length ? productChannelFilter : ''}
               onChange={handleFilterChange}>
               <MenuItem value="all">All Rules</MenuItem>
               {productChannelOptions.map(option => (


### PR DESCRIPTION
A fix for the error below that shows up in the console when the Rules page is reloaded with a productChannelFilter set to a value that is not 'all'.

![Screenshot from 2023-12-14 19-30-58](https://github.com/mozilla-releng/balrog/assets/84005549/1e5b0805-0850-4671-807f-78d8c39d7530)
