### PR TITLE
Guard against non-xml releases in xml get_update_blob

### DIFF
--- a/src/auslib/web/public/client.py
+++ b/src/auslib/web/public/client.py
@@ -7,7 +7,8 @@ from flask import current_app as app
 from flask import make_response
 
 from auslib.AUS import FORCE_FALLBACK_MAPPING, FORCE_MAIN_MAPPING
-from auslib.blobs.base import createBlob
+from auslib.blobs.base import XMLBlob, createBlob
+from auslib.errors import BadDataError
 from auslib.global_state import dbo
 from auslib.services import releases
 from auslib.web.public.helpers import AUS, get_aus_metadata_headers, get_content_signature_headers, with_transaction
@@ -147,6 +148,8 @@ def get_update_blob(transaction, **url):
 
     # passing {},None returns empty xml
     if release:
+        if not isinstance(release, XMLBlob):
+            raise BadDataError("Wrong blob type")
         response_products = release.getResponseProducts()
         response_blobs = []
         response_blob_names = release.getResponseBlobs()

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -457,3 +457,9 @@ def testGuardianResponseV2WithGradualRollout(client, forceValue, response):
     assert ret.get_json() == response
     assert ret.headers["Content-Signature"] == "x5u=https://this.is/a.x5u; p384ecdsa=abcdef"
     auslib.web.public.helpers.make_hash.assert_called_once_with(ret.text)
+
+
+@pytest.mark.usefixtures("guardian_db")
+def testXMLForGuardianBlob(client):
+    ret = client.get("/update/1/Guardian/0.4.0.0/default/WINNT_x86_64/en-US/release/update.xml")
+    assert ret.status_code == 400


### PR DESCRIPTION
Fixes #3069

There might be a cleaner/cleverer way to do this?