### PR TITLE
Add filter query to url on roles page

### DIFF
--- a/ui/src/views/Roles/ListRoles/index.jsx
+++ b/ui/src/views/Roles/ListRoles/index.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useState, useEffect, useMemo } from 'react';
+import { stringify, parse } from 'qs';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import { makeStyles } from '@material-ui/styles';
 import List from '@material-ui/core/List';
@@ -33,8 +34,10 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function ListRoles() {
+function ListRoles(props) {
   const classes = useStyles();
+  const { search } = props.location;
+  const query = parse(search.slice(1));
   const [usersAction, fetchUsers] = useAction(getUsers);
   const [roleFilter, setRoleFilter] = useState(ALL);
   const isLoading = usersAction.loading;
@@ -75,6 +78,13 @@ function ListRoles() {
 
   const handleFilterChange = ({ target: { value } }) => {
     setRoleFilter(value);
+
+    const qs = {
+      ...query,
+      role: value !== 'all' ? value : undefined,
+    };
+
+    props.history.push(`/roles${stringify(qs, { addQueryPrefix: true })}`);
   };
 
   return (


### PR DESCRIPTION
Add filter query to the url on the roles page.

Before:
![Screenshot from 2023-12-22 15-41-58](https://github.com/mozilla-releng/balrog/assets/84005549/f236b52a-b0ce-4ef8-85c8-f1541794bb36)

Now:
![Screenshot from 2023-12-22 15-42-14](https://github.com/mozilla-releng/balrog/assets/84005549/57c73332-e5c8-4809-99b1-82da9e1be719)
