### PR TITLE
Disable release uploads when no user logged in

### DIFF
--- a/ui/src/components/ReleaseCard/index.jsx
+++ b/ui/src/components/ReleaseCard/index.jsx
@@ -340,11 +340,11 @@ function ReleaseCard(props) {
               : `/releases/${release.name}/v2`
           }>
           <Button color="secondary">
-            {release.read_only ? 'View' : 'Update'}
+            {!user || release.read_only ? 'View' : 'Update'}
           </Button>
         </Link>
         <Button
-          disabled={release.read_only || hasRulesPointingAtRevision}
+          disabled={!user || release.read_only || hasRulesPointingAtRevision}
           color="secondary"
           onClick={() => onReleaseDelete(release)}>
           Delete

--- a/ui/src/views/Releases/Release/index.jsx
+++ b/ui/src/views/Releases/Release/index.jsx
@@ -293,7 +293,7 @@ function Release(props) {
           <div className={classes.uploadReleaseDiv}>
             <label htmlFor="upload-release-file">
               <input
-                disabled={isReadOnly}
+                disabled={!user || isReadOnly}
                 accept=".json"
                 className={classes.inputOfTypeFile}
                 id="upload-release-file"
@@ -301,7 +301,7 @@ function Release(props) {
                 onChange={handleUploadRelease}
               />
               <Button
-                disabled={isReadOnly}
+                disabled={!user || isReadOnly}
                 size="small"
                 variant="outlined"
                 component="span"


### PR DESCRIPTION
1. Change the release card update to view when no user
2. Disable delete on release card when no user
2. Disable release uploads when no user

Releases List Page:
Before:
![Screenshot from 2024-01-08 16-38-33](https://github.com/mozilla-releng/balrog/assets/84005549/715b7f0e-8454-43b0-b5a2-bbd31ecb38f2)

After:
![Screenshot from 2024-01-08 16-37-24](https://github.com/mozilla-releng/balrog/assets/84005549/ec84019e-ada0-43b5-9e9f-e7a7e59f17c6)

Release View Page
Before:
![Screenshot from 2024-01-08 16-38-23](https://github.com/mozilla-releng/balrog/assets/84005549/0b1c70e4-93d7-42ae-a7d9-e4fb650627bd)

After:
![Screenshot from 2024-01-08 16-37-39](https://github.com/mozilla-releng/balrog/assets/84005549/47d2df25-cf31-4335-9cea-b2d295b60593)
