### PR TITLE
fix: guard against unparsable nightly release names in cleanup script

### DIFF
--- a/scripts/manage-db.py
+++ b/scripts/manage-db.py
@@ -19,11 +19,13 @@ sys.path.append(path.join(path.dirname(__file__), ".."))
 sys.path.append(path.join(path.dirname(__file__), path.join("..", "vendor", "lib", "python")))
 
 
+# TODO: filter out things that don't end in 14 digits
 RELEASES_CLEANUP_CONDITION = """
 LEFT JOIN rules rules_mapping ON (name=rules_mapping.mapping)
 WHERE name LIKE '%%nightly%%'
 AND name NOT LIKE '%%latest'
 AND rules_mapping.mapping IS NULL
+AND RIGHT(name, 14) REGEXP '^[[:digit:]]*$'
 AND (STR_TO_DATE(RIGHT(name, 14), "%%Y%%m%%d%%H%%i%%S") < NOW() - INTERVAL {nightly_age} DAY);
 """
 


### PR DESCRIPTION
I discovered this issue while testing the cleanup script in stage, which had a release with a name like "Firefox-mozilla-central-nightly-20170731100325-2". The dry run of the cleanup script worked fine, but when it tried to delete it threw an error about not being able to parse it as a date. After some digging, I discovered that this is because the dryrun's `SELECT` uses an index, while the `DELETE` does not. (I don't know why this is - but it doesn't affect the behaviour of the script beyond making the `DELETE` look at some rows that it won't be deleting anayways...)

In any case, we may as well make sure the names we're about to parse are actually parsable.