### PR TITLE
feat: enable sentry integration for manage-db.py functions

### DIFF
--- a/scripts/manage-db.py
+++ b/scripts/manage-db.py
@@ -2,6 +2,7 @@
 
 import itertools
 import logging
+import os
 import sys
 from os import path
 from subprocess import run
@@ -195,6 +196,11 @@ if __name__ == "__main__":
         parser.error("need an action to perform")
 
     action = args[0]
+
+    if os.environ.get("SENTRY_DSN"):
+        import sentry_sdk
+
+        sentry_sdk.init(os.environ["SENTRY_DSN"])
 
     db = AUSDatabase(options.db, mysql_traditional_mode=True)
     if action == "create":


### PR DESCRIPTION
This is primarily aimed at the cleanup/database dump cronjobs, which currently have no visibility, but I imagine it will also be helpful for database upgrades as well.

Unfortunately, there's no good way to test this until it hits staging...