### PR TITLE
Bug 1912274 - Update domain allowlist for Widevine

### DIFF
--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -26,6 +26,10 @@ DOMAIN_ALLOWLIST = {
     "ciscobinary.openh264.org": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),
     "clients2.googleusercontent.com": ("Widevine",),
+    "edgedl.me.gvt1.com": (
+        "Widevine",
+        "Widevine-L1",
+    ),
     "redirector.gvt1.com": (
         "Widevine",
         "Widevine-L1",

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -27,6 +27,10 @@ DOMAIN_ALLOWLIST = {
     "ciscobinary.openh264.org": ("OpenH264",),
     "cdmdownload.adobe.com": ("CDM",),
     "clients2.googleusercontent.com": ("Widevine",),
+    "edgedl.me.gvt1.com": (
+        "Widevine",
+        "Widevine-L1",
+    ),
     "redirector.gvt1.com": (
         "Widevine",
         "Widevine-L1",


### PR DESCRIPTION
Add a new domain to the Widevine allowlist.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1912274#c4