### PR TITLE
Bug 1915359 - error handling for update_release without data_version

### DIFF
--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -490,6 +490,8 @@ def update_release(name, blob, old_data_versions, when, changed_by, trans):
         if current_assets.get(str_path):
             if item != current_assets[str_path]["data"]:
                 old_data_version = get_by_path(old_data_versions, path)
+                if not old_data_version:
+                    raise ValueError(f"Missing data_version for {str_path}")
                 new_assets = current_assets[str_path]["data"]
                 release_merger.merge(new_assets, item)
                 ensure_path_exists(full_blob, path)


### PR DESCRIPTION
When trying to update a release, if the client didn't send old data_version for a pre-existing platform/locale entry, we would crash with a TypeError and return 500.  We now explicitly check for that case, and return an explicit 400 to the client.