### PR TITLE
Bug 1933266 - Add support for mirror URLs for GMP plugins.

### DIFF
--- a/src/auslib/blobs/gmp.py
+++ b/src/auslib/blobs/gmp.py
@@ -70,10 +70,28 @@ class GMPBlobV1(XMLBlob):
             url = platformData["fileUrl"]
             if isForbiddenUrl(url, updateQuery["product"], allowlistedDomains):
                 continue
+            mirrorUrls = []
+            if "mirrorUrls" in platformData:
+                for mirrorUrl in platformData["mirrorUrls"]:
+                    if isForbiddenUrl(mirrorUrl, updateQuery["product"], allowlistedDomains):
+                        continue
+                    mirrorUrls.append(mirrorUrl)
             vendorXML.append(
-                '        <addon id="%s" URL="%s" hashFunction="%s" hashValue="%s" size="%s" version="%s"/>'
-                % (vendor, url, self["hashFunction"], platformData["hashValue"], platformData["filesize"], vendorInfo["version"])
+                '        <addon id="%s" URL="%s" hashFunction="%s" hashValue="%s" size="%s" version="%s"%s>'
+                % (
+                    vendor,
+                    url,
+                    self["hashFunction"],
+                    platformData["hashValue"],
+                    platformData["filesize"],
+                    vendorInfo["version"],
+                    "" if mirrorUrls else "/",
+                )
             )
+            if mirrorUrls:
+                for mirrorUrl in mirrorUrls:
+                    vendorXML.append('            <mirror URL="%s"/>' % (mirrorUrl))
+                vendorXML.append("        </addon>")
 
         return vendorXML
 
@@ -85,4 +103,8 @@ class GMPBlobV1(XMLBlob):
                 if "fileUrl" in platform:
                     if isForbiddenUrl(platform["fileUrl"], product, allowlistedDomains):
                         return True
+                if "mirrorUrls" in platform:
+                    for mirrorUrl in platform["mirrorUrls"]:
+                        if isForbiddenUrl(mirrorUrl, product, allowlistedDomains):
+                            return True
         return False

--- a/src/auslib/blobs/schemas/gmp.yml
+++ b/src/auslib/blobs/schemas/gmp.yml
@@ -65,7 +65,18 @@
                         hashValue:
                           type: string
                           description: The hash (using the "hashFunction" algorithm) of the file for this vendor+platform combination. The client uses this to help verify it after downloading.
+                        # For backwards compatibility reasons, fileUrl and mirrorUrls are two
+                        # separate properties, both containing URLs from which the addon can be
+                        # downloaded. The fileUrl is the primary URL which should be tried first.
+                        # If that fails and the client supports it, it should attempt the mirror
+                        # URLs in the given order.
                         fileUrl:
                           type: string
                           description: Where the client can download the file for this vendor+platform combination.
                           format: uri
+                        mirrorUrls:
+                          type: array
+                          description: Alternative locations where the client can download the file for this vendor+platform combination.
+                          items:
+                            type: string
+                            format: uri


### PR DESCRIPTION
This patch adds support for alternative URLs from which the GMP plugin can be downloaded. This is useful for GMP plugins, particularly Widevine, because there are many different mirrors from Google. Some users have trouble accessing the preferred mirror due to networking issues, so it would be ideal to supply alternative domains that are more likely to resolve/be reachable as a backup.