### PR TITLE
fix(docker): Switch to `pip install` and remove `repoze-lru` workaround

### DIFF
--- a/maintenance/pin-helper.sh
+++ b/maintenance/pin-helper.sh
@@ -18,7 +18,6 @@ apt-get update
 # --allow-unsafe is required because local dev environments need all deps hashed to install properly
 ARGS="-g base -g docs -g test -g local --backtracking --allow-unsafe"
 pip-compile-multi -o "$SUFFIX" $ARGS $EXTRA_PCM_ARGS
-sed -i 's/^repoze-lru/repoze.lru/' requirements/*.txt
 chmod 644 requirements/*.txt
 
 cd agent

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1172,7 +1172,7 @@ referencing==0.36.1 \
     # via
     #   jsonschema
     #   jsonschema-specifications
-repoze.lru==0.7 \
+repoze-lru==0.7 \
     --hash=sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77 \
     --hash=sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea
     # via -r requirements/base.in

--- a/taskcluster/docker/balrog-backend/Dockerfile
+++ b/taskcluster/docker/balrog-backend/Dockerfile
@@ -38,7 +38,7 @@ COPY topsrcdir/scripts/manage-db.py topsrcdir/scripts/run-batch-deletes.sh topsr
 # %include version.txt
 COPY topsrcdir/MANIFEST.in topsrcdir/pyproject.toml topsrcdir/setup.py topsrcdir/version.json topsrcdir/version.txt /app/
 
-RUN python setup.py install
+RUN pip install .
 
 WORKDIR /app
 


### PR DESCRIPTION
- Replaces `python setup.py install` with `pip install` in the Docker image
- Removes the hard-coded `repoze.lru` (`-` to `.`) workaround in `pin-helper`

The issue arose because `pip-compile` switches `.` to `-` when following [PEP-0503](https://peps.python.org/pep-0503/#normalized-names) package name normalization rules. While `pip` seamlessly handles the aliased name (installing the package with `.`), `setuptools` does not manage the mismatch well. By moving to `pip install`, we avoid the naming conflict entirely and prevent future mishaps.