### PR TITLE
Add a `pr-complete` task that we can require before merging PRs

### DIFF
--- a/taskcluster/kinds/pr/kind.yml
+++ b/taskcluster/kinds/pr/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 kind-dependencies:
     - test
+    - ui
 
 transforms:
     - taskgraph.transforms.code_review:transforms

--- a/taskcluster/kinds/pr/kind.yml
+++ b/taskcluster/kinds/pr/kind.yml
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+kind-dependencies:
+    - test
+
+transforms:
+    - taskgraph.transforms.code_review:transforms
+    - taskgraph.transforms.task:transforms
+
+tasks:
+    complete:
+        description: PR Summary Task
+        run-on-tasks-for: [github-pull-request]
+        worker-type: succeed

--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -11,6 +11,8 @@ transforms:
 
 task-defaults:
         run-on-tasks-for: [github-pull-request, github-push]
+        attributes:
+          code-review: true
         worker-type: test
         worker:
             docker-image: {in-tree: 'python3.11'}

--- a/taskcluster/kinds/ui/kind.yml
+++ b/taskcluster/kinds/ui/kind.yml
@@ -10,6 +10,8 @@ transforms:
 
 task-defaults:
         run-on-tasks-for: [github-pull-request, github-push]
+        attributes:
+          code-review: true
         worker-type: test
         worker:
             docker-image: {in-tree: node}


### PR DESCRIPTION
The task does nothing, always succeeds but depends on all test tasks passing.