### PR TITLE
Set `LC_ALL=C.UTF-8` in docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM python:3.13-slim
 
+ENV LC_ALL C.UTF-8
+
 LABEL maintainer="releng@mozilla.com"
 
 # uwsgi needs libpcre3 for routing support to be enabled.

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,8 @@
 ARG PYTHON_VERSION=3.13
 FROM python:${PYTHON_VERSION}-slim
 
+ENV LC_ALL C.UTF-8
+
 LABEL maintainer="releng@mozilla.com"
 
 # netcat is needed for health checks

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.13-slim
 
 MAINTAINER jcristau@mozilla.com
 
+ENV LC_ALL C.UTF-8
+
 WORKDIR /app
 
 COPY requirements/ /app/requirements/

--- a/agent/Dockerfile.test
+++ b/agent/Dockerfile.test
@@ -4,6 +4,8 @@ FROM python:3.13-slim
 
 MAINTAINER jcristau@mozilla.com
 
+ENV LC_ALL C.UTF-8
+
 WORKDIR /app
 
 COPY requirements/ /app/requirements/

--- a/taskcluster/docker/balrog-agent/Dockerfile
+++ b/taskcluster/docker/balrog-agent/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.13-slim
 
 MAINTAINER jcristau@mozilla.com
 
+ENV LC_ALL C.UTF-8
+
 WORKDIR /app
 
 # %include agent/requirements

--- a/taskcluster/docker/balrog-backend/Dockerfile
+++ b/taskcluster/docker/balrog-backend/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM python:3.13-slim
 
+ENV LC_ALL C.UTF-8
+
 # uwsgi needs libpcre3 for routing support to be enabled.
 # default-libmysqlclient-dev is required to use SQLAlchemy with MySQL, which we do in production.
 # xz-utils is needed to compress production database dumps

--- a/taskcluster/docker/python/Dockerfile
+++ b/taskcluster/docker/python/Dockerfile
@@ -5,6 +5,8 @@
 ARG  PYTHON_VERSION
 FROM python:$PYTHON_VERSION
 
+ENV LC_ALL C.UTF-8
+
 # Add worker user
 RUN mkdir -p /builds && \
     groupadd -g 1000 -o worker && \


### PR DESCRIPTION
Python 3.13 dropped that in https://github.com/docker-library/python/pull/895 Without this, running balrog locally results in

```
balrogadmin-1  |   File "/app/uwsgi/admin.wsgi", line 74, in <module>
balrogadmin-1  |     from auslib.web.admin.base import app as application  # noqa
balrogadmin-1  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
balrogadmin-1  |   File "/app/src/auslib/web/admin/base.py", line 29, in <module>
balrogadmin-1  |     .add_spec(path.join(current_dir, "swagger/api.yml"))
balrogadmin-1  |      ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
balrogadmin-1  |   File "/usr/local/lib/python3.13/site-packages/specsynthase/specbuilder.py", line 44, in add_spec
balrogadmin-1  |     spec = self._load_spec(file_name)
balrogadmin-1  |   File "/usr/local/lib/python3.13/site-packages/specsynthase/specbuilder.py", line 13, in _load_spec
balrogadmin-1  |     return yaml.load(spec_file, Loader=yaml.FullLoader)
balrogadmin-1  |            ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
balrogadmin-1  |   File "/usr/local/lib/python3.13/site-packages/yaml/__init__.py", line 79, in load
balrogadmin-1  |     loader = Loader(stream)
balrogadmin-1  |   File "/usr/local/lib/python3.13/site-packages/yaml/loader.py", line 24, in __init__
balrogadmin-1  |     Reader.__init__(self, stream)
balrogadmin-1  |     ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
balrogadmin-1  |   File "/usr/local/lib/python3.13/site-packages/yaml/reader.py", line 85, in __init__
balrogadmin-1  |     self.determine_encoding()
balrogadmin-1  |     ~~~~~~~~~~~~~~~~~~~~~~~^^
balrogadmin-1  |   File "/usr/local/lib/python3.13/site-packages/yaml/reader.py", line 124, in determine_encoding
balrogadmin-1  |     self.update_raw()
balrogadmin-1  |     ~~~~~~~~~~~~~~~^^
balrogadmin-1  |   File "/usr/local/lib/python3.13/site-packages/yaml/reader.py", line 178, in update_raw
balrogadmin-1  |     data = self.stream.read(size)
balrogadmin-1  |   File "/usr/local/lib/python3.13/encodings/ascii.py", line 26, in decode
balrogadmin-1  |     return codecs.ascii_decode(input, self.errors)[0]
balrogadmin-1  |            ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
balrogadmin-1  | UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 773: ordinal not in range(128)
balrogadmin-1 exited with code 22
```

Because our swagger config contains some non ASCII characters so it cannot be read to a string if `LANG` is unset which defaults to `POSIX` (at least on my system).

I probably went overboard by setting it into every python container as some might not actually require it, but I feel like everyone would expect a UTF-8 locale to be set.

```
[eijemoz@plutonium] ~  >>> docker run -it python:3.11-slim /bin/bash
root@8ad1bc142b44:/# locale
LANG=C.UTF-8
LANGUAGE=
LC_CTYPE="C.UTF-8"
LC_NUMERIC="C.UTF-8"
LC_TIME="C.UTF-8"
LC_COLLATE="C.UTF-8"
LC_MONETARY="C.UTF-8"
LC_MESSAGES="C.UTF-8"
LC_PAPER="C.UTF-8"
LC_NAME="C.UTF-8"
LC_ADDRESS="C.UTF-8"
LC_TELEPHONE="C.UTF-8"
LC_MEASUREMENT="C.UTF-8"
LC_IDENTIFICATION="C.UTF-8"
LC_ALL=
root@8ad1bc142b44:/#
exit
[eijemoz@plutonium] ~  >>> docker run -it python:3.13-slim /bin/bash
root@c1be2f814191:/# locale
LANG=
LANGUAGE=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
```