### PR TITLE
web: rename app to flask_app

### DIFF
--- a/tests/admin/views/base.py
+++ b/tests/admin/views/base.py
@@ -8,7 +8,7 @@ import pytest
 
 from auslib.blobs.base import createBlob
 from auslib.global_state import cache, dbo
-from auslib.web.admin.base import app
+from auslib.web.admin.base import flask_app as app
 
 from ...fakes import FakeBlob, FakeGCSHistory
 

--- a/tests/admin/views/conftest.py
+++ b/tests/admin/views/conftest.py
@@ -17,7 +17,7 @@ def mock_verified_userinfo(monkeypatch):
 
 @pytest.fixture(scope="session")
 def api():
-    from auslib.web.admin.base import app
+    from auslib.web.admin.base import flask_app as app
 
     app.config["SECRET_KEY"] = "notasecret"
     app.config["CORS_ORIGINS"] = "*"

--- a/tests/blobs/test_apprelease.py
+++ b/tests/blobs/test_apprelease.py
@@ -23,7 +23,7 @@ from auslib.blobs.apprelease import (
 from auslib.blobs.base import createBlob
 from auslib.errors import BadDataError, BlobValidationError
 from auslib.global_state import dbo
-from auslib.web.public.base import app
+from auslib.web.public.base import flask_app as app
 
 from ..fakes import FakeGCSHistory
 

--- a/tests/web/api/base.py
+++ b/tests/web/api/base.py
@@ -5,7 +5,7 @@ import pytest
 
 from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
-from auslib.web.public.base import app
+from auslib.web.public.base import flask_app as app
 
 
 def setUpModule():

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -17,7 +17,7 @@ import auslib.web.public.client as client_api
 from auslib.blobs.base import createBlob
 from auslib.errors import BadDataError
 from auslib.global_state import cache, dbo
-from auslib.web.public.base import app
+from auslib.web.public.base import flask_app as app
 from auslib.web.public.client import extract_query_version
 
 mock_autograph_exception_count = 0

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -7,7 +7,7 @@ import auslib.web.public.json
 from auslib.AUS import FORCE_FALLBACK_MAPPING, FORCE_MAIN_MAPPING
 from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
-from auslib.web.public.base import app
+from auslib.web.public.base import flask_app as app
 
 
 @pytest.fixture(scope="function")

--- a/tests/web/test_unicode.py
+++ b/tests/web/test_unicode.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 
 from auslib.global_state import dbo
-from auslib.web.public.base import app
+from auslib.web.public.base import flask_app as app
 
 
 @pytest.mark.usefixtures("current_db_schema")


### PR DESCRIPTION
We have a Connexion app which wraps a Flask app, so having something called `app` can get confusing.