### PR TITLE
tests: exclude "-1" from from bad inputs for the `force` parameter

### DIFF
--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -1325,6 +1325,7 @@ class ClientTest(ClientTestBase):
     @example('"|sleep 7 #')
     def testForceParamWithBadInputs(self, x):
         assume(x != "1")
+        assume(x != "-1")
         force_output = """<?xml version="1.0"?>
 <updates>
     <update type="minor" version="1.0" extensionVersion="1.0" buildID="2">


### PR DESCRIPTION
-1 is valid (meaning "force fallback mapping"), and the test fails with that value.