### PR TITLE
tests: fix disabling of flask error handlers

### DIFF
--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -197,9 +197,7 @@ class AUSTransaction(object):
             if exc_type:
                 self.log.debug("exc is:", exc_info=True)
                 self.rollback()
-                e = exc_type(exc_value)
-                e.__traceback__ = exc_traceback
-                raise e
+                return False
             # self.commit will issue a rollback if it raises
             self.commit()
         finally:

--- a/tests/web/api/base.py
+++ b/tests/web/api/base.py
@@ -1,5 +1,6 @@
 import logging
 import unittest
+from collections import defaultdict
 
 import pytest
 
@@ -19,8 +20,8 @@ class CommonTestBase(unittest.TestCase):
     def setUpClass(cls):
         # Error handlers are removed in order to give us better debug messages
         cls.error_spec = app.error_handler_spec
-        # Ripped from https://github.com/mitsuhiko/flask/blob/1f5927eee2288b4aaf508af5dc1f148aa2140d91/flask/app.py#L394
-        app.error_handler_spec = {None: {}}
+        # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
+        app.error_handler_spec = defaultdict(lambda: defaultdict(dict))
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -1374,8 +1374,11 @@ class ClientTest(ClientTestBase):
     def testGMPResponseWithSigningAutographPermanentFailure(self):
         global mock_autograph_exception_count
         mock_autograph_exception_count = 3
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as excinfo:
             self.client.get("/update/4/gmp/1.0/1/p/l/a/a/a/a/1/update.xml")
+
+        assert excinfo.type is Exception
+        assert excinfo.value.args == ("unable to contact autograph",)
 
     def testGetWithResponseProducts(self):
         ret = self.client.get("/update/4/gmp/1.0/1/p/l/a/a/a/a/1/update.xml")

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 import unittest
+from collections import defaultdict
 from contextlib import ExitStack
 from tempfile import mkstemp
 from xml.dom import minidom
@@ -117,8 +118,8 @@ class ClientTestBase(ClientTestCommon):
     def setUpClass(cls):
         # Error handlers are removed in order to give us better debug messages
         cls.error_spec = app.error_handler_spec
-        # Ripped from https://github.com/mitsuhiko/flask/blob/1f5927eee2288b4aaf508af5dc1f148aa2140d91/flask/app.py#L394
-        app.error_handler_spec = {None: {}}
+        # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
+        app.error_handler_spec = defaultdict(lambda: defaultdict(dict))
 
     @classmethod
     def tearDownClass(cls):
@@ -1784,8 +1785,8 @@ class ClientTestMig64(ClientTestCommon):
     def setUpClass(cls):
         # Error handlers are removed in order to give us better debug messages
         cls.error_spec = app.error_handler_spec
-        # Ripped from https://github.com/mitsuhiko/flask/blob/1f5927eee2288b4aaf508af5dc1f148aa2140d91/flask/app.py#L394
-        app.error_handler_spec = {None: {}}
+        # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
+        app.error_handler_spec = defaultdict(lambda: defaultdict(dict))
 
     @classmethod
     def tearDownClass(cls):
@@ -1956,8 +1957,8 @@ class ClientTestJaws(ClientTestCommon):
     def setUpClass(cls):
         # Error handlers are removed in order to give us better debug messages
         cls.error_spec = app.error_handler_spec
-        # Ripped from https://github.com/mitsuhiko/flask/blob/1f5927eee2288b4aaf508af5dc1f148aa2140d91/flask/app.py#L394
-        app.error_handler_spec = {None: {}}
+        # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
+        app.error_handler_spec = defaultdict(lambda: defaultdict(dict))
 
     @classmethod
     def tearDownClass(cls):
@@ -2391,8 +2392,8 @@ class ClientTestCompactXML(ClientTestCommon):
     def setUpClass(cls):
         # Error handlers are removed in order to give us better debug messages
         cls.error_spec = app.error_handler_spec
-        # Ripped from https://github.com/mitsuhiko/flask/blob/1f5927eee2288b4aaf508af5dc1f148aa2140d91/flask/app.py#L394
-        app.error_handler_spec = {None: {}}
+        # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
+        app.error_handler_spec = defaultdict(lambda: defaultdict(dict))
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,7 +13,8 @@ from auslib.web.public.base import flask_app as app
 
 @pytest.fixture(scope="function")
 def disable_errorhandler(monkeypatch):
-    monkeypatch.setattr(app, "error_handler_spec", {None: {}})
+    # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
+    monkeypatch.setattr(app, "error_handler_spec", defaultdict(lambda: defaultdict(dict)))
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
As far as I can tell this has been broken since
https://github.com/pallets/flask/commit/fd62210f583e90764be6e8d9f295f37f33a65e48