### PR TITLE
fix: use flask_app in wsgi files

### DIFF
--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -71,7 +71,7 @@ log = logging.getLogger(__file__)
 statsd.defaults.PREFIX = "balrog.admin.cache"
 
 from auslib.global_state import cache, dbo  # noqa
-from auslib.web.admin.base import app as application  # noqa
+from auslib.web.admin.base import flask_app as application  # noqa
 
 cache.make_copies = True
 # We explicitly don't want a blob_version cache here because it will cause

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -68,7 +68,7 @@ configure_logging(**logging_kwargs)
 statsd.defaults.PREFIX = "balrog.public.cache"
 
 from auslib.global_state import cache, dbo  # noqa
-from auslib.web.public.base import app as application  # noqa
+from auslib.web.public.base import flask_app as application  # noqa
 
 if os.environ.get("AUTOGRAPH_URL"):
     application.config["AUTOGRAPH_URL"] = os.environ["AUTOGRAPH_URL"]


### PR DESCRIPTION
Follow-up to #3435 where `app` was renamed to `flask_app`.