### PR TITLE
Use a factory to create the app object

### DIFF
--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -30,146 +30,136 @@ spec = (
 
 validator_map = {"body": BalrogRequestBodyValidator}
 
-connexion_app = connexion.App(__name__, debug=False, options={"swagger_ui": False})
-connexion_app.add_api(spec, validator_map=validator_map, strict_validation=True)
-connexion_app.add_api(path.join(current_dir, "swagger", "api_v2.yml"), base_path="/v2", strict_validation=True, validate_responses=True)
-flask_app = connexion_app.app
 
-create_dockerflow_endpoints(flask_app)
+def create_app():
+    connexion_app = connexion.App(__name__, debug=False, options={"swagger_ui": False})
+    connexion_app.add_api(spec, validator_map=validator_map, strict_validation=True)
+    connexion_app.add_api(path.join(current_dir, "swagger", "api_v2.yml"), base_path="/v2", strict_validation=True, validate_responses=True)
+    flask_app = connexion_app.app
 
+    create_dockerflow_endpoints(flask_app)
 
-@flask_app.before_request
-def setup_request():
-    if request.full_path.startswith("/v2"):
-        from auslib.global_state import dbo
+    @flask_app.before_request
+    def setup_request():
+        if request.full_path.startswith("/v2"):
+            from auslib.global_state import dbo
 
-        request.transaction = dbo.begin()
+            request.transaction = dbo.begin()
 
-        if request.method in ("POST", "PUT", "DELETE"):
-            username = verified_userinfo(request, flask_app.config["AUTH_DOMAIN"], flask_app.config["AUTH_AUDIENCE"])["email"]
-            if not username:
-                log.warning("Login Required")
-                return problem(401, "Unauthenticated", "Login Required")
-            # Machine to machine accounts are identified by uninformative clientIds
-            # In order to keep Balrog permissions more readable, we map them to
-            # more useful usernames, which are stored in the app config.
-            if "@" not in username:
-                username = flask_app.config["M2M_ACCOUNT_MAPPING"].get(username, username)
-            # Even if the user has provided a valid access token, we don't want to assume
-            # that person should be able to access Balrog (in case auth0 is not configured
-            # to be restrictive enough.
-            elif not dbo.isKnownUser(username):
-                log.warning("Authorization Required")
-                return problem(403, "Forbidden", "Authorization Required")
+            if request.method in ("POST", "PUT", "DELETE"):
+                username = verified_userinfo(request, flask_app.config["AUTH_DOMAIN"], flask_app.config["AUTH_AUDIENCE"])["email"]
+                if not username:
+                    log.warning("Login Required")
+                    return problem(401, "Unauthenticated", "Login Required")
+                # Machine to machine accounts are identified by uninformative clientIds
+                # In order to keep Balrog permissions more readable, we map them to
+                # more useful usernames, which are stored in the app config.
+                if "@" not in username:
+                    username = flask_app.config["M2M_ACCOUNT_MAPPING"].get(username, username)
+                # Even if the user has provided a valid access token, we don't want to assume
+                # that person should be able to access Balrog (in case auth0 is not configured
+                # to be restrictive enough.
+                elif not dbo.isKnownUser(username):
+                    log.warning("Authorization Required")
+                    return problem(403, "Forbidden", "Authorization Required")
 
-            request.username = username
+                request.username = username
 
+    @flask_app.after_request
+    def complete_request(response):
+        if hasattr(request, "transaction"):
+            try:
+                if response.status_code >= 400:
+                    request.transaction.rollback()
+                else:
+                    request.transaction.commit()
+            finally:
+                request.transaction.close()
 
-@flask_app.after_request
-def complete_request(response):
-    if hasattr(request, "transaction"):
-        try:
-            if response.status_code >= 400:
-                request.transaction.rollback()
-            else:
-                request.transaction.commit()
-        finally:
-            request.transaction.close()
+        return response
 
-    return response
+    @flask_app.errorhandler(OutdatedDataError)
+    def outdated_data_error(error):
+        msg = "Couldn't perform the request %s. Outdated Data Version. old_data_version doesn't match current data_version" % request.method
+        log.warning("Bad input: %s", msg)
+        log.warning(error)
+        return problem(400, "Bad Request", "OutdatedDataError", ext={"exception": msg})
 
+    @flask_app.errorhandler(UpdateMergeError)
+    def update_merge_error(error):
+        msg = "Couldn't perform the request %s due to merge error. Is there a scheduled change that conflicts with yours?" % request.method
+        log.warning("Bad input: %s", msg)
+        log.warning(error)
+        return problem(400, "Bad Request", "UpdateMergeError", ext={"exception": msg})
 
-@flask_app.errorhandler(OutdatedDataError)
-def outdated_data_error(error):
-    msg = "Couldn't perform the request %s. Outdated Data Version. old_data_version doesn't match current data_version" % request.method
-    log.warning("Bad input: %s", msg)
-    log.warning(error)
-    return problem(400, "Bad Request", "OutdatedDataError", ext={"exception": msg})
+    @flask_app.errorhandler(ChangeScheduledError)
+    def change_scheduled_error(error):
+        msg = "Couldn't perform the request %s due a conflict with a scheduled change. " % request.method
+        msg += str(error)
+        log.warning("Bad input: %s", msg)
+        log.warning(error)
+        return problem(400, "Bad Request", "ChangeScheduledError", ext={"exception": msg})
 
+    @flask_app.errorhandler(AuthError)
+    def auth_error(error):
+        msg = "Permission denied to perform the request. {}".format(error.error)
+        log.warning(msg)
+        return problem(error.status_code, "Forbidden", "PermissionDeniedError", ext={"exception": msg})
 
-@flask_app.errorhandler(UpdateMergeError)
-def update_merge_error(error):
-    msg = "Couldn't perform the request %s due to merge error. Is there a scheduled change that conflicts with yours?" % request.method
-    log.warning("Bad input: %s", msg)
-    log.warning(error)
-    return problem(400, "Bad Request", "UpdateMergeError", ext={"exception": msg})
+    @flask_app.errorhandler(BlobValidationError)
+    def blob_validation_error(error):
+        return problem(400, "Bad Request", "Invalid Blob", ext={"exception": error.errors})
 
+    @flask_app.errorhandler(SignoffRequiredError)
+    def signoff_required_error(error):
+        return problem(400, "Bad Request", "Signoff Required", ext={"exception": f"{error}"})
 
-@flask_app.errorhandler(ChangeScheduledError)
-def change_scheduled_error(error):
-    msg = "Couldn't perform the request %s due a conflict with a scheduled change. " % request.method
-    msg += str(error)
-    log.warning("Bad input: %s", msg)
-    log.warning(error)
-    return problem(400, "Bad Request", "ChangeScheduledError", ext={"exception": msg})
+    @flask_app.errorhandler(ReadOnlyError)
+    def read_only_error(error):
+        return problem(400, "Bad Request", "Read only", ext={"exception": f"{error}"})
 
+    @flask_app.errorhandler(PermissionDeniedError)
+    def permission_denied_error(error):
+        return problem(403, "Forbidden", "Permission Denied", ext={"exception": f"{error}"})
 
-@flask_app.errorhandler(AuthError)
-def auth_error(error):
-    msg = "Permission denied to perform the request. {}".format(error.error)
-    log.warning(msg)
-    return problem(error.status_code, "Forbidden", "PermissionDeniedError", ext={"exception": msg})
+    @flask_app.errorhandler(ValueError)
+    def value_error(error):
+        return problem(400, "Bad Request", "Unknown error", ext={"exception": f"{error}"})
 
+    # Connexion's error handling sometimes breaks when parameters contain
+    # unicode characters (https://github.com/zalando/connexion/issues/604).
+    # To work around, we catch them and return a 400 (which is what Connexion
+    # would do if it didn't hit this error).
+    @flask_app.errorhandler(UnicodeEncodeError)
+    def unicode(error):
+        return problem(400, "Unicode Error", "Connexion was unable to parse some unicode data correctly.")
 
-@flask_app.errorhandler(BlobValidationError)
-def blob_validation_error(error):
-    return problem(400, "Bad Request", "Invalid Blob", ext={"exception": error.errors})
+    @flask_app.errorhandler(Exception)
+    def ise(error):
+        capture_exception(error)
+        log.exception("Caught ISE 500 error: %r", error)
+        log.debug("Request path is: %s", request.path)
+        log.debug("Request environment is: %s", request.environ)
+        log.debug("Request headers are: %s", request.headers)
+        return problem(500, "Internal Server Error", "Internal Server Error")
 
+    @flask_app.after_request
+    def add_security_headers(response):
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Strict-Transport-Security"] = flask_app.config.get("STRICT_TRANSPORT_SECURITY", "max-age=31536000;")
+        response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
+        response.headers["Access-Control-Allow-Methods"] = "OPTIONS, GET, POST, PUT, DELETE"
+        if "*" in flask_app.config["CORS_ORIGINS"]:
+            response.headers["Access-Control-Allow-Origin"] = "*"
+        elif "Origin" in request.headers and request.headers["Origin"] in flask_app.config["CORS_ORIGINS"]:
+            response.headers["Access-Control-Allow-Origin"] = request.headers["Origin"]
+        if re.match("^/ui/", request.path):
+            # This enables swagger-ui to dynamically fetch and
+            # load the swagger specification JSON file containing API definition and examples.
+            response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        else:
+            response.headers["Content-Security-Policy"] = flask_app.config.get("CONTENT_SECURITY_POLICY", "default-src 'none'; frame-ancestors 'none'")
+        return response
 
-@flask_app.errorhandler(SignoffRequiredError)
-def signoff_required_error(error):
-    return problem(400, "Bad Request", "Signoff Required", ext={"exception": f"{error}"})
-
-
-@flask_app.errorhandler(ReadOnlyError)
-def read_only_error(error):
-    return problem(400, "Bad Request", "Read only", ext={"exception": f"{error}"})
-
-
-@flask_app.errorhandler(PermissionDeniedError)
-def permission_denied_error(error):
-    return problem(403, "Forbidden", "Permission Denied", ext={"exception": f"{error}"})
-
-
-@flask_app.errorhandler(ValueError)
-def value_error(error):
-    return problem(400, "Bad Request", "Unknown error", ext={"exception": f"{error}"})
-
-
-# Connexion's error handling sometimes breaks when parameters contain
-# unicode characters (https://github.com/zalando/connexion/issues/604).
-# To work around, we catch them and return a 400 (which is what Connexion
-# would do if it didn't hit this error).
-@flask_app.errorhandler(UnicodeEncodeError)
-def unicode(error):
-    return problem(400, "Unicode Error", "Connexion was unable to parse some unicode data correctly.")
-
-
-@flask_app.errorhandler(Exception)
-def ise(error):
-    capture_exception(error)
-    log.exception("Caught ISE 500 error: %r", error)
-    log.debug("Request path is: %s", request.path)
-    log.debug("Request environment is: %s", request.environ)
-    log.debug("Request headers are: %s", request.headers)
-    return problem(500, "Internal Server Error", "Internal Server Error")
-
-
-@flask_app.after_request
-def add_security_headers(response):
-    response.headers["X-Frame-Options"] = "DENY"
-    response.headers["X-Content-Type-Options"] = "nosniff"
-    response.headers["Strict-Transport-Security"] = flask_app.config.get("STRICT_TRANSPORT_SECURITY", "max-age=31536000;")
-    response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
-    response.headers["Access-Control-Allow-Methods"] = "OPTIONS, GET, POST, PUT, DELETE"
-    if "*" in flask_app.config["CORS_ORIGINS"]:
-        response.headers["Access-Control-Allow-Origin"] = "*"
-    elif "Origin" in request.headers and request.headers["Origin"] in flask_app.config["CORS_ORIGINS"]:
-        response.headers["Access-Control-Allow-Origin"] = request.headers["Origin"]
-    if re.match("^/ui/", request.path):
-        # This enables swagger-ui to dynamically fetch and
-        # load the swagger specification JSON file containing API definition and examples.
-        response.headers["X-Frame-Options"] = "SAMEORIGIN"
-    else:
-        response.headers["Content-Security-Policy"] = flask_app.config.get("CONTENT_SECURITY_POLICY", "default-src 'none'; frame-ancestors 'none'")
-    return response
+    return connexion_app

--- a/src/auslib/web/public/base.py
+++ b/src/auslib/web/public/base.py
@@ -15,9 +15,6 @@ from auslib.web.admin.views.problem import problem
 
 log = logging.getLogger(__name__)
 
-connexion_app = connexion.App(__name__, specification_dir=".", options={"swagger_ui": False})
-flask_app = connexion_app.app
-
 current_dir = path.dirname(__file__)
 web_dir = path.dirname(auslib.web.__file__)
 spec = (
@@ -28,105 +25,104 @@ spec = (
     .add_spec(path.join(web_dir, "common/swagger/parameters.yml"))
     .add_spec(path.join(web_dir, "common/swagger/responses.yml"))
 )
-# Response validation should be enabled when it actually works
-connexion_app.add_api(spec, strict_validation=True)
 
 
-@flask_app.after_request
-def apply_security_headers(response):
-    # There's no use cases for content served by Balrog to load additional content
-    # nor be embedded elsewhere, so we apply a strict Content Security Policy.
-    # We also need to set X-Content-Type-Options to nosniff for Firefox to obey this.
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1332829#c4 for background.
-    response.headers["Strict-Transport-Security"] = flask_app.config.get("STRICT_TRANSPORT_SECURITY", "max-age=31536000;")
-    response.headers["X-Content-Type-Options"] = flask_app.config.get("CONTENT_TYPE_OPTIONS", "nosniff")
-    if re.match("^/ui/", request.path):
-        # This enables swagger-ui to dynamically fetch and
-        # load the swagger specification JSON file containing API definition and examples.
-        response.headers["X-Frame-Options"] = "SAMEORIGIN"
-    else:
-        response.headers["Content-Security-Policy"] = flask_app.config.get("CONTENT_SECURITY_POLICY", "default-src 'none'; frame-ancestors 'none'")
-    return response
+def create_app():
+    connexion_app = connexion.App(__name__, specification_dir=".", options={"swagger_ui": False})
+    flask_app = connexion_app.app
 
+    # Response validation should be enabled when it actually works
+    connexion_app.add_api(spec, strict_validation=True)
 
-@flask_app.errorhandler(404)
-def fourohfour(error):
-    if re.match("^/update", request.path):
-        """We don't return 404s for AUS /update endpoints. Instead, we return empty XML files"""
-        response = make_response('<?xml version="1.0"?>\n<updates>\n</updates>')
-        response.mimetype = "text/xml"
+    @flask_app.after_request
+    def apply_security_headers(response):
+        # There's no use cases for content served by Balrog to load additional content
+        # nor be embedded elsewhere, so we apply a strict Content Security Policy.
+        # We also need to set X-Content-Type-Options to nosniff for Firefox to obey this.
+        # See https://bugzilla.mozilla.org/show_bug.cgi?id=1332829#c4 for background.
+        response.headers["Strict-Transport-Security"] = flask_app.config.get("STRICT_TRANSPORT_SECURITY", "max-age=31536000;")
+        response.headers["X-Content-Type-Options"] = flask_app.config.get("CONTENT_TYPE_OPTIONS", "nosniff")
+        if re.match("^/ui/", request.path):
+            # This enables swagger-ui to dynamically fetch and
+            # load the swagger specification JSON file containing API definition and examples.
+            response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        else:
+            response.headers["Content-Security-Policy"] = flask_app.config.get("CONTENT_SECURITY_POLICY", "default-src 'none'; frame-ancestors 'none'")
         return response
-    return Response(status=404, mimetype="text/plain", response=error.description)
 
+    @flask_app.errorhandler(404)
+    def fourohfour(error):
+        if re.match("^/update", request.path):
+            """We don't return 404s for AUS /update endpoints. Instead, we return empty XML files"""
+            response = make_response('<?xml version="1.0"?>\n<updates>\n</updates>')
+            response.mimetype = "text/xml"
+            return response
+        return Response(status=404, mimetype="text/plain", response=error.description)
 
-# Connexion's error handling sometimes breaks when parameters contain
-# unicode characters (https://github.com/zalando/connexion/issues/604).
-# To work around, we catch them and return a 400 (which is what Connexion
-# would do if it didn't hit this error).
-@flask_app.errorhandler(UnicodeEncodeError)
-def unicode(error):
-    return problem(400, "Unicode Error", "Connexion was unable to parse some unicode data correctly.")
+    # Connexion's error handling sometimes breaks when parameters contain
+    # unicode characters (https://github.com/zalando/connexion/issues/604).
+    # To work around, we catch them and return a 400 (which is what Connexion
+    # would do if it didn't hit this error).
+    @flask_app.errorhandler(UnicodeEncodeError)
+    def unicode(error):
+        return problem(400, "Unicode Error", "Connexion was unable to parse some unicode data correctly.")
 
+    @flask_app.errorhandler(BadDataError)
+    def baddata(error):
+        """Deals with BadDataError exceptions by returning a 400,
+        because BadDataErrors are considered to be the client's fault.
+        """
+        # Escape exception messages before replying with them, because they may
+        # contain user input.
+        # See https://bugzilla.mozilla.org/show_bug.cgi?id=1332829 for background.
+        # We used to look at error.message here, but that disappeared from many
+        # Exception classes in Python 3, so args is the safer bet.
+        # We may want to stop returning messages like this to the client altogether
+        # both because it's ugly and potentially can leak things, but it's also
+        # extremely helpful for debugging BadDataErrors, because we don't send
+        # information about them to Sentry.
+        if hasattr(error, "args"):
+            message = " ".join(str(a) for a in error.args)
+        else:
+            message = repr(error)
 
-@flask_app.errorhandler(BadDataError)
-def baddata(error):
-    """Deals with BadDataError exceptions by returning a 400,
-    because BadDataErrors are considered to be the client's fault.
-    """
-    # Escape exception messages before replying with them, because they may
-    # contain user input.
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1332829 for background.
-    # We used to look at error.message here, but that disappeared from many
-    # Exception classes in Python 3, so args is the safer bet.
-    # We may want to stop returning messages like this to the client altogether
-    # both because it's ugly and potentially can leak things, but it's also
-    # extremely helpful for debugging BadDataErrors, because we don't send
-    # information about them to Sentry.
-    if hasattr(error, "args"):
-        message = " ".join(str(a) for a in error.args)
-    else:
-        message = repr(error)
+        return Response(status=400, mimetype="text/plain", response=html.escape(message, quote=False))
 
-    return Response(status=400, mimetype="text/plain", response=html.escape(message, quote=False))
+    @flask_app.errorhandler(Exception)
+    def generic(error):
+        """Deals with any unhandled exceptions. It will be sent to Sentry, and re-raised (which causes a 500)."""
 
+        # Sentry doesn't handle exceptions for `@flask_app.errorhandler(Exception)`
+        # implicitly. If Sentry is not configured, the following call returns None.
+        capture_exception(error)
 
-@flask_app.errorhandler(Exception)
-def generic(error):
-    """Deals with any unhandled exceptions. It will be sent to Sentry, and re-raised (which causes a 500)."""
+        raise
 
-    # Sentry doesn't handle exceptions for `@flask_app.errorhandler(Exception)`
-    # implicitly. If Sentry is not configured, the following call returns None.
-    capture_exception(error)
+    # Keeping static files endpoints here due to an issue when returning response for static files.
+    # Similar issue: https://github.com/zalando/connexion/issues/401
+    @flask_app.route("/robots.txt")
+    def robots():
+        return send_from_directory(flask_app.static_folder, "robots.txt")
 
-    raise
+    @flask_app.route("/contribute.json")
+    def contributejson():
+        return send_from_directory(flask_app.static_folder, "contribute.json")
 
+    @flask_app.before_request
+    def set_cache_control():
+        # By default, we want a cache that can be shared across requests from
+        # different users ("public").
+        # and a maximum age of 90 seconds, to keep our TTL low.
+        # We bumped this from 60s -> 90s in November, 2016.
+        setattr(flask_app, "cacheControl", flask_app.config.get("CACHE_CONTROL", "public, max-age=90"))
 
-# Keeping static files endpoints here due to an issue when returning response for static files.
-# Similar issue: https://github.com/zalando/connexion/issues/401
-@flask_app.route("/robots.txt")
-def robots():
-    return send_from_directory(flask_app.static_folder, "robots.txt")
+    @flask_app.route("/debug/api.yml")
+    def get_yaml():
+        if flask_app.config.get("SWAGGER_DEBUG", False):
+            import yaml
 
+            app_spec = yaml.dump(spec)
+            return Response(mimetype="text/plain", response=app_spec)
+        return Response(status=404)
 
-@flask_app.route("/contribute.json")
-def contributejson():
-    return send_from_directory(flask_app.static_folder, "contribute.json")
-
-
-@flask_app.before_request
-def set_cache_control():
-    # By default, we want a cache that can be shared across requests from
-    # different users ("public").
-    # and a maximum age of 90 seconds, to keep our TTL low.
-    # We bumped this from 60s -> 90s in November, 2016.
-    setattr(flask_app, "cacheControl", flask_app.config.get("CACHE_CONTROL", "public, max-age=90"))
-
-
-@flask_app.route("/debug/api.yml")
-def get_yaml():
-    if flask_app.config.get("SWAGGER_DEBUG", False):
-        import yaml
-
-        app_spec = yaml.dump(spec)
-        return Response(mimetype="text/plain", response=app_spec)
-    return Response(status=404)
+    return connexion_app

--- a/tests/admin/views/base.py
+++ b/tests/admin/views/base.py
@@ -9,7 +9,6 @@ import pytest
 from auslib.blobs.base import createBlob
 from auslib.global_state import cache, dbo
 from auslib.util.auth import AuthError
-from auslib.web.admin.base import flask_app as app
 
 from ...fakes import FakeBlob, FakeGCSHistory
 
@@ -25,7 +24,7 @@ class ViewTest(unittest.TestCase):
     some helper methods."""
 
     @pytest.fixture(autouse=True)
-    def setup(self, insert_release, firefox_56_0_build1):
+    def setup(self, insert_release, firefox_56_0_build1, app):
         from auslib.web.admin.views import base as view_base
 
         self.view_base = view_base
@@ -47,7 +46,6 @@ class ViewTest(unittest.TestCase):
         self.version_fd, self.version_file = mkstemp()
         cache.reset()
         cache.make_copies = True
-        saved_config = app.config.copy()
         app.config["SECRET_KEY"] = "abc123"
         app.config["DEBUG"] = True
         app.config["ALLOWLISTED_DOMAINS"] = {"good.com": ("a", "b", "c", "d")}
@@ -424,7 +422,6 @@ class ViewTest(unittest.TestCase):
         os.remove(self.version_file)
         self.view_base.verified_userinfo = self.orig_base_verified_userinfo
         dbo.releases.history = self.orig_releases_history
-        app.config = saved_config
 
     def _get(self, url, qs={}, username=None):
         headers = {"Accept-Encoding": "application/json", "Accept": "application/json"}

--- a/tests/admin/views/conftest.py
+++ b/tests/admin/views/conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 import auslib.web.admin.base
 from auslib.util.auth import AuthError
+from auslib.web.admin.base import create_app
 
 
 @pytest.fixture(scope="function")
@@ -20,8 +21,9 @@ def mock_verified_userinfo(monkeypatch):
 
 @pytest.fixture(scope="session")
 def api():
-    from auslib.web.admin.base import flask_app as app
 
+    connexion_app = create_app()
+    app = connexion_app.app
     app.config["SECRET_KEY"] = "notasecret"
     app.config["CORS_ORIGINS"] = "*"
     app.config["AUTH_DOMAIN"] = "balrog.test.dev"
@@ -34,3 +36,9 @@ def api():
     }
 
     return app.test_client()
+
+
+@pytest.fixture(scope="class")
+def app():
+    connexion_app = create_app()
+    return connexion_app.app

--- a/tests/web/api/base.py
+++ b/tests/web/api/base.py
@@ -6,7 +6,7 @@ import pytest
 
 from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
-from auslib.web.public.base import flask_app as app
+from auslib.web.public.base import create_app
 
 
 def setUpModule():
@@ -18,19 +18,16 @@ def setUpModule():
 class CommonTestBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        connexion_app = create_app()
+        cls.app = connexion_app.app
         # Error handlers are removed in order to give us better debug messages
-        cls.error_spec = app.error_handler_spec
         # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
-        app.error_handler_spec = defaultdict(lambda: defaultdict(dict))
-
-    @classmethod
-    def tearDownClass(cls):
-        app.error_handler_spec = cls.error_spec
+        cls.app.error_handler_spec = defaultdict(lambda: defaultdict(dict))
 
     @pytest.fixture(autouse=True)
     def setup(self, insert_release, firefox_54_0_1_build1, firefox_56_0_build1, superblob_e8f4a19, hotfix_bug_1548973_1_1_4, timecop_1_0):
-        app.config["DEBUG"] = True
-        self.public_client = app.test_client()
+        self.app.config["DEBUG"] = True
+        self.public_client = self.app.test_client()
 
         dbo.setDb("sqlite:///:memory:")
         self.metadata.create_all(dbo.engine)

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,0 +1,19 @@
+from collections import defaultdict
+
+import pytest
+
+from auslib.web.public.base import create_app
+
+
+@pytest.fixture(scope="class")
+def app(request):
+    connexion_app = create_app()
+    app = request.cls.app = connexion_app.app
+    return app
+
+
+@pytest.fixture(scope="class")
+def propagate_exceptions(app):
+    # Error handlers are removed in order to give us better debug messages
+    # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
+    app.error_handler_spec = defaultdict(lambda: defaultdict(dict))

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -8,17 +8,23 @@ import auslib.web.public.json
 from auslib.AUS import FORCE_FALLBACK_MAPPING, FORCE_MAIN_MAPPING
 from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
-from auslib.web.public.base import flask_app as app
+from auslib.web.public.base import create_app
+
+
+@pytest.fixture(scope="module")
+def app():
+    connexion_app = create_app()
+    return connexion_app.app
 
 
 @pytest.fixture(scope="function")
-def disable_errorhandler(monkeypatch):
+def disable_errorhandler(monkeypatch, app):
     # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
     monkeypatch.setattr(app, "error_handler_spec", defaultdict(lambda: defaultdict(dict)))
 
 
 @pytest.fixture(scope="function")
-def mock_autograph(monkeypatch):
+def mock_autograph(monkeypatch, app):
     monkeypatch.setitem(app.config, "AUTOGRAPH_URL", "fake")
     monkeypatch.setitem(app.config, "AUTOGRAPH_KEYID", "fake")
     monkeypatch.setitem(app.config, "AUTOGRAPH_USERNAME", "fake")
@@ -32,7 +38,7 @@ def mock_autograph(monkeypatch):
 
 
 @pytest.fixture(scope="module")
-def appconfig():
+def appconfig(app):
     app.config["ALLOWLISTED_DOMAINS"] = {"good.com": ("Guardian",)}
 
 
@@ -228,7 +234,7 @@ def guardian_db():
 
 
 @pytest.fixture(scope="module")
-def client():
+def client(app):
     return app.test_client()
 
 

--- a/tests/web/test_unicode.py
+++ b/tests/web/test_unicode.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 
 from auslib.global_state import dbo
-from auslib.web.public.base import flask_app as app
+from auslib.web.public.base import create_app
 
 
 @pytest.mark.usefixtures("current_db_schema")
@@ -11,7 +11,8 @@ class UnicodeTest(unittest.TestCase):
     def setUp(self):
         dbo.setDb("sqlite:///:memory:")
         self.metadata.create_all(dbo.engine)
-        self.client = app.test_client()
+        connexion_app = create_app()
+        self.client = connexion_app.app.test_client()
 
     def testUnicodeInRoute(self):
         url = "/update/3/GMP/53.0/20170421105455/Linux_x86_64-gcc3/null/{}/Linux%204.4.0-53-generic%20(GTK%203.18.9,libpulse%208.0.0)/mint/1.0/update.xml"

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -71,7 +71,9 @@ log = logging.getLogger(__file__)
 statsd.defaults.PREFIX = "balrog.admin.cache"
 
 from auslib.global_state import cache, dbo  # noqa
-from auslib.web.admin.base import flask_app as application  # noqa
+from auslib.web.admin.base import create_app
+
+application = create_app().app
 
 cache.make_copies = True
 # We explicitly don't want a blob_version cache here because it will cause

--- a/uwsgi/public.wsgi
+++ b/uwsgi/public.wsgi
@@ -68,7 +68,9 @@ configure_logging(**logging_kwargs)
 statsd.defaults.PREFIX = "balrog.public.cache"
 
 from auslib.global_state import cache, dbo  # noqa
-from auslib.web.public.base import flask_app as application  # noqa
+from auslib.web.public.base import create_app
+
+application = create_app().app
 
 if os.environ.get("AUTOGRAPH_URL"):
     application.config["AUTOGRAPH_URL"] = os.environ["AUTOGRAPH_URL"]


### PR DESCRIPTION
Instead of creating the flask/connexion app at import time, do it when `create_app()` is called.  This makes it easier for different tests to use a different app object with different config, especially with the port to connexion 3, where some config settings aren't meant to be changed after the app has started being used.