### PR TITLE
Don't use the `db_schema` fixture in `guardian_db`

### DIFF
--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -37,8 +37,10 @@ def appconfig():
 
 
 @pytest.fixture(scope="module")
-def guardian_db(db_schema):
-    db_schema.create_all(dbo.engine)
+def guardian_db():
+    dbo.setDb("sqlite:///:memory:")
+    dbo.create()
+    dbo.metadata.create_all(dbo.engine)
     dbo.releases.t.insert().execute(
         name="Guardian-Evil-1.0.0.0",
         product="Guardian",


### PR DESCRIPTION
The db_schema fixture is session scopes while the guardian_db one is module scoped. If the guardian_db fixture is used in tests that get run out of order, the module fixture gets called again and explodes because it's inserting into the session database again.

For example if tests are ran like this:

- test_json:A
- another_module:Foo
- test_json:B

It would result in:

- db_schema
- guardian_db
- test_json:A
- another_module:Foo
- guardian_db # BOOM
- test_json:B

This should hopefully fix the intermittent we've been seeing in test_json