### PR TITLE
Don't emit warnings more than once when running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     --no-deps
     -r {toxinidir}/requirements/test.txt
 commands =
-    {posargs:pytest -n auto --cov=auslib --cov-config=tox.ini --cov-report=term-missing --cov-append tests}
+    {posargs:pytest -n auto --cov=auslib --cov-config=tox.ini --cov-report=term-missing --cov-append -Wonce tests}
     coverage run -a scripts/test-rules.py
 
 [testenv:clean]


### PR DESCRIPTION
Locally this makes tests go from 45s to 38s
We don't need to see every warning more than once to know why it's there...