### PR TITLE
tests: set app.testing instead of poking through flask internals

### DIFF
--- a/tests/admin/views/conftest.py
+++ b/tests/admin/views/conftest.py
@@ -24,6 +24,7 @@ def api():
 
     connexion_app = create_app()
     app = connexion_app.app
+    app.testing = True
     app.config["SECRET_KEY"] = "notasecret"
     app.config["CORS_ORIGINS"] = "*"
     app.config["AUTH_DOMAIN"] = "balrog.test.dev"
@@ -41,4 +42,6 @@ def api():
 @pytest.fixture(scope="class")
 def app():
     connexion_app = create_app()
-    return connexion_app.app
+    app = connexion_app.app
+    app.testing = True
+    return app

--- a/tests/web/api/base.py
+++ b/tests/web/api/base.py
@@ -1,12 +1,10 @@
 import logging
 import unittest
-from collections import defaultdict
 
 import pytest
 
 from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
-from auslib.web.public.base import create_app
 
 
 def setUpModule():
@@ -14,15 +12,8 @@ def setUpModule():
     logging.getLogger("migrate").setLevel(logging.CRITICAL)
 
 
-@pytest.mark.usefixtures("current_db_schema")
+@pytest.mark.usefixtures("current_db_schema", "app")
 class CommonTestBase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        connexion_app = create_app()
-        cls.app = connexion_app.app
-        # Error handlers are removed in order to give us better debug messages
-        # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
-        cls.app.error_handler_spec = defaultdict(lambda: defaultdict(dict))
 
     @pytest.fixture(autouse=True)
     def setup(self, insert_release, firefox_54_0_1_build1, firefox_56_0_build1, superblob_e8f4a19, hotfix_bug_1548973_1_1_4, timecop_1_0):

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 import pytest
 
 from auslib.web.public.base import create_app
@@ -9,11 +7,5 @@ from auslib.web.public.base import create_app
 def app(request):
     connexion_app = create_app()
     app = request.cls.app = connexion_app.app
+    app.testing = True
     return app
-
-
-@pytest.fixture(scope="class")
-def propagate_exceptions(app):
-    # Error handlers are removed in order to give us better debug messages
-    # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
-    app.error_handler_spec = defaultdict(lambda: defaultdict(dict))

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -109,7 +109,7 @@ class ClientTestCommon(unittest.TestCase):
         self.assertEqual(returned, expected)
 
 
-@pytest.mark.usefixtures("propagate_exceptions")
+@pytest.mark.usefixtures("app")
 class ClientTestBase(ClientTestCommon):
     maxDiff = 2000
 
@@ -1776,7 +1776,7 @@ class ClientTest(ClientTestBase):
         )
 
 
-@pytest.mark.usefixtures("propagate_exceptions")
+@pytest.mark.usefixtures("app")
 class ClientTestMig64(ClientTestCommon):
     """Tests the expected real world scenarios for the mig64 query parameter.
     mig64=0 is not tested because we have no client code that sends it. These
@@ -1939,7 +1939,7 @@ class ClientTestMig64(ClientTestCommon):
         )
 
 
-@pytest.mark.usefixtures("propagate_exceptions")
+@pytest.mark.usefixtures("app")
 class ClientTestJaws(ClientTestCommon):
     """Tests the expected real world scenarios for the JAWS parameter in
     SYSTEM_CAPABILITIES."""
@@ -2326,7 +2326,7 @@ class ClientTestWithErrorHandlers(ClientTestCommon):
         self.assertEqual(ret.status_code, 400)
 
 
-@pytest.mark.usefixtures("propagate_exceptions")
+@pytest.mark.usefixtures("app")
 class ClientTestCompactXML(ClientTestCommon):
     """Tests the compact XML needed to rescue two Firefox nightlies (bug 1517743)."""
 

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from unittest.mock import MagicMock
 
 import pytest
@@ -14,13 +13,9 @@ from auslib.web.public.base import create_app
 @pytest.fixture(scope="module")
 def app():
     connexion_app = create_app()
+    app = connexion_app.app
+    app.testing = True
     return connexion_app.app
-
-
-@pytest.fixture(scope="function")
-def disable_errorhandler(monkeypatch, app):
-    # Ripped from https://github.com/pallets/flask/blob/2.3.3/src/flask/scaffold.py#L131-L134
-    monkeypatch.setattr(app, "error_handler_spec", defaultdict(lambda: defaultdict(dict)))
 
 
 @pytest.fixture(scope="function")
@@ -238,7 +233,7 @@ def client(app):
     return app.test_client()
 
 
-@pytest.mark.usefixtures("appconfig", "guardian_db", "disable_errorhandler", "mock_autograph")
+@pytest.mark.usefixtures("appconfig", "guardian_db", "mock_autograph")
 @pytest.mark.parametrize(
     "version,buildTarget,channel,code,response",
     [
@@ -283,7 +278,7 @@ def testGuardianResponseV1(client, version, buildTarget, channel, code, response
         assert "Rule-Data-Version" in ret.headers
 
 
-@pytest.mark.usefixtures("appconfig", "guardian_db", "disable_errorhandler")
+@pytest.mark.usefixtures("appconfig", "guardian_db")
 @pytest.mark.parametrize(
     "version,buildTarget,channel,code,response",
     [
@@ -319,7 +314,7 @@ def testGuardianResponseV1WithoutSigning(client, version, buildTarget, channel, 
         assert "Content-Signature" not in ret.headers
 
 
-@pytest.mark.usefixtures("appconfig", "guardian_db", "disable_errorhandler", "mock_autograph")
+@pytest.mark.usefixtures("appconfig", "guardian_db", "mock_autograph")
 @pytest.mark.parametrize(
     "forceValue,response",
     [
@@ -343,7 +338,7 @@ def testGuardianResponseV1WithGradualRollout(client, forceValue, response):
     auslib.web.public.helpers.make_hash.assert_called_once_with(ret.text)
 
 
-@pytest.mark.usefixtures("appconfig", "guardian_db", "disable_errorhandler", "mock_autograph")
+@pytest.mark.usefixtures("appconfig", "guardian_db", "mock_autograph")
 @pytest.mark.parametrize(
     "version,buildTarget,channel,osVersion,code,response",
     [
@@ -407,7 +402,7 @@ def testGuardianResponseV2(client, version, buildTarget, channel, osVersion, cod
         assert "Rule-Data-Version" in ret.headers
 
 
-@pytest.mark.usefixtures("appconfig", "guardian_db", "disable_errorhandler")
+@pytest.mark.usefixtures("appconfig", "guardian_db")
 @pytest.mark.parametrize(
     "version,buildTarget,channel,osVersion,code,response",
     [
@@ -446,7 +441,7 @@ def testGuardianResponseV2WithoutSigning(client, version, buildTarget, channel, 
         assert "Content-Signature" not in ret.headers
 
 
-@pytest.mark.usefixtures("appconfig", "guardian_db", "disable_errorhandler", "mock_autograph")
+@pytest.mark.usefixtures("appconfig", "guardian_db", "mock_autograph")
 @pytest.mark.parametrize(
     "forceValue,response",
     [

--- a/tests/web/test_unicode.py
+++ b/tests/web/test_unicode.py
@@ -12,6 +12,7 @@ class UnicodeTest(unittest.TestCase):
         dbo.setDb("sqlite:///:memory:")
         self.metadata.create_all(dbo.engine)
         connexion_app = create_app()
+        connexion_app.app.testing = True
         self.client = connexion_app.app.test_client()
 
     def testUnicodeInRoute(self):


### PR DESCRIPTION
We can tell flask to let exceptions propagate by setting the testing flag.  So do that consistently, and for the one test class that wants to test the error handlers, we already explicitly set PROPAGATE_EXCEPTIONS to False.