### PR TITLE
maintenance: silence pip warnings

### DIFF
--- a/maintenance/pin-helper.sh
+++ b/maintenance/pin-helper.sh
@@ -7,8 +7,9 @@ if [ $# -gt 0 ]; then
     EXTRA_PCM_ARGS="$@"
 fi
 
-pip install --upgrade 'pip<25.1'
-pip install 'pip-compile-multi<3'
+PIP="pip --disable-pip-version-check install --root-user-action ignore"
+$PIP --upgrade 'pip<25.1'
+$PIP 'pip-compile-multi<3'
 
 apt-get update
 


### PR DESCRIPTION
- we use an old version of pip on purpose, so there's no point for it to check if there are newer versions
- pin-helper runs in a throwaway container, so there's no extra risk from running as root