### PR TITLE
docker-compose: reduce balrogdb health check interval

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,9 +181,9 @@ services:
       driver: none
     healthcheck:
         test: nc -z -v balrogdb 3306
-        interval: 30s
+        interval: 5s
         timeout: 30s
-        retries: 10
+        retries: 50
 
   # TODO: provide our own config so that we can guarantee the keyid
   autograph:


### PR DESCRIPTION
Check for mysql status more frequently so we don't have to wait 30s to start the app after the db is up.