### PR TITLE
admin: let nginx rewrite /api/foo to /foo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     volumes:
       - ./agent:/app
     environment:
-      - BALROG_API_ROOT=http://nginx:8011/api
+      - BALROG_API_ROOT=http://nginx:8011
       - BALROG_USERNAME=balrogagent
       - BALROG_PASSWORD=na
       - TELEMETRY_API_ROOT=abc

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -27,6 +27,7 @@ server {
 
 
     location / {
+        rewrite ^/api/(.*)$ /$1;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
 
@@ -55,6 +56,7 @@ server {
     # I haven't determined yet...
     listen $NGINX_BALROG_AGENT_PORT;
     location / {
+        rewrite ^/api/(.*)$ /$1;
         proxy_redirect off;
         proxy_pass $BALROG_ADMIN_ROOT;
         proxy_http_version 1.1;

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -1,5 +1,5 @@
 export const USER_SESSION = 'react-auth0-session';
-export const BASE_URL = `${process.env.BALROG_ROOT_URL}/api`;
+export const BASE_URL = `${process.env.BALROG_ROOT_URL}`;
 export const OBJECT_NAMES = {
   PERMISSIONS_REQUIRED_SIGNOFF: 'required_signoffs/permissions',
   PRODUCT_REQUIRED_SIGNOFF: 'required_signoffs/product',

--- a/uwsgi/admin.ini
+++ b/uwsgi/admin.ini
@@ -1,9 +1,4 @@
 [uwsgi]
 http = :$(PORT)
-
-# Mount the admin app at /api, for historical reasons.
-# At some point we could consider mounting at 
-mount = /api=/app/uwsgi/admin.wsgi
-# Rewrite PATH_INFO & SCRIPT_NAME to match mountpoint (so the app sees paths like /foo instead of /api/foo)
-manage-script-name = 1
+wsgi-file = /app/uwsgi/admin.wsgi
 enable-threads = true


### PR DESCRIPTION
Instead of having the admin app available both at / and /api, let nginx rewrite requests for /api/foo to /foo for backwards compatibility, and remove the extra uwsgi mount at /api.