### PR TITLE
Don't use refresh tokens with auth0

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -21,8 +21,6 @@ const App = () => {
           scope: process.env.AUTH0_SCOPE,
         }}
         leeway={30}
-        useRefreshTokens
-        useRefreshTokensFallback
         cacheLocation="localstorage">
         <ThemeProvider theme={theme}>
           <Main />


### PR DESCRIPTION
Those get rejected because they require MFA again, which doesn't work very well when you try to do that silently leading to weird errors where the frontend thinks the user is authenticated but can't actually get a proper access token. They were not used either before this but I thought it was because of a misconfiguration of the previous library, not because it wouldn't work. (it worked well when doing local dev since our auth0 tenant for balrog localdev doesn't have mfa enabled... Lesson learned here, do auth0 experiments on shipit instead)