### PR TITLE
Fix all actions being disabled on the rules list all the time

### DIFF
--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -1379,7 +1379,7 @@ function ListRules(props) {
           onRevoke={() => handleRevoke(rule)}
           onViewReleaseClick={handleViewRelease}
           diffRules={showRewindDiff}
-          disableActions={!props.user || Boolean(rewindDate)}
+          disableActions={!props.auth0.user || Boolean(rewindDate)}
           actionLoading={isActionLoading}
         />
       </div>


### PR DESCRIPTION
While migrating the auth0 library, the user property got replaced by auth0 and it seems that I missed this one spot when adapting it.

The result would be `props.user` being `undefined` (yay javascript...), and thus `disableActions` would always be true.