### PR TITLE
Move the frontend configuration directly into the task environment

### DIFF
--- a/taskcluster/kinds/push-js/kind.yml
+++ b/taskcluster/kinds/push-js/kind.yml
@@ -25,6 +25,8 @@ task-defaults:
     worker:
         docker-image: {in-tree: node}
         max-run-time: 3600
+        env:
+          AUTH0_DOMAIN: auth.mozilla.auth0.com
     dependencies:
           tests-js: ui-tests
           build-ui: ui-build
@@ -34,12 +36,17 @@ tasks:
         description: "Staging UI deploy"
         scopes:
             - secrets:get:repo:github.com/mozilla-releng/balrog:s3-stage-aws-creds
-            - secrets:get:repo:github.com/mozilla-releng/balrog:s3-stage-app-config
         worker:
             env:
                 AWS_CREDENTIALS_SECRET: http://taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/balrog:s3-stage-aws-creds
-                APP_CONFIG_SECRET: http://taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/balrog:s3-stage-app-config
                 WEBSITE_BUCKET: balrog-stage-balrog-static-admin-stage-static-website
+                # Frontend configuration
+                AUTH0_AUDIENCE: balrog-cloudops-stage
+                AUTH0_CLIENT_ID: 43tgBNjaHHhOAPPr10zh2jodVT3t6abD
+                AUTH0_REDIRECT_URI: https://balrog-admin-static-stage.stage.mozaws.net/login
+                BALROG_ROOT_URL: https://admin-stage.balrog.nonprod.cloudops.mozgcp.net
+                GCS_NIGHTLY_HISTORY_BUCKET: https://www.googleapis.com/storage/v1/b/balrog-stage-nightly-history-v1/o
+                GCS_RELEASES_HISTORY_BUCKET: https://www.googleapis.com/storage/v1/b/balrog-stage-release-history-v1/o
         run-on-releases:
             - v
 
@@ -47,11 +54,16 @@ tasks:
         description: "Production UI deploy"
         scopes:
             - secrets:get:repo:github.com/mozilla-releng/balrog:s3-prod-aws-creds
-            - secrets:get:repo:github.com/mozilla-releng/balrog:s3-prod-app-config
         worker:
             env:
                 AWS_CREDENTIALS_SECRET: http://taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/balrog:s3-prod-aws-creds
-                APP_CONFIG_SECRET: http://taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/balrog:s3-prod-app-config
                 WEBSITE_BUCKET: balrog-prod-balrog-static-admin-prod-static-website
+                # Frontend configuration
+                AUTH0_AUDIENCE: balrog-production
+                AUTH0_CLIENT_ID: Qe16eoq0Uz9eSTVDVEO15DGBPCgqoAA2
+                AUTH0_REDIRECT_URI: https://balrog.services.mozilla.com/login
+                BALROG_ROOT_URL: https://aus4-admin.mozilla.org
+                GCS_NIGHTLY_HISTORY_BUCKET: https://www.googleapis.com/storage/v1/b/balrog-prod-nightly-history-v1/o
+                GCS_RELEASES_HISTORY_BUCKET: https://www.googleapis.com/storage/v1/b/balrog-prod-release-history-v1/o
         run-on-releases:
             - production-ui$

--- a/ui/scripts/deploy
+++ b/ui/scripts/deploy
@@ -3,13 +3,17 @@
 set -o errexit -o pipefail
 set -e
 
+test $AWS_CREDENTIALS_SECRET
+test $WEBSITE_BUCKET
+test $BALROG_ROOT_URL
+test $AUTH0_CLIENT_ID
+test $AUTH0_AUDIENCE
+test $AUTH0_REDIRECT_URI
+test $GCS_NIGHTLY_HISTORY_BUCKET
+test $GCS_RELEASES_HISTORY_BUCKET
+
 export AWS_ACCESS_KEY_ID=$(curl ${AWS_CREDENTIALS_SECRET} | python3 -c 'import json, sys; a = json.load(sys.stdin); print(a["secret"]["aws_access_key"])')
 export AWS_SECRET_ACCESS_KEY=$(curl ${AWS_CREDENTIALS_SECRET} | python3 -c 'import json, sys; a = json.load(sys.stdin); print(a["secret"]["aws_secret_key"])')
-
-# Grab app config and convert it to shell format
-curl "${APP_CONFIG_SECRET}" | python3 -c 'import json, sys; a = json.load(sys.stdin); [print("{}=\"{}\"".format(k, v)) for k,v in a["secret"].items()]' > .env
-
-source .env
 
 HEADERS=$(cat <<EOF
 { \


### PR DESCRIPTION
This was set by fetching a secret from taskcluster containing only public values, then put into a .env file which was finally exposed through `dotenv` in `packages.json`. Since all of those values are actually public, there's no need to go through that whole process and we can store those values into the task definition.

This brings deployment of balrog more in line with what shipit does (although shipit stores those in the taskgraph config and then copies it into the task environment but I don't see a point in doing that). It also means that we can now search for those values... When the dotenv PR broke staging, it took a while before someone figured out that those values were coming from a secret because there were no mentions of them anywhere that was deployment related. And it'll allow us to remove the dependency of dotenv.

I decided to put `GCS_NIGHTLY_HISTORY_BUCKET` and
`GCS_RELEASES_HISTORY_BUCKET` in the prod config despite them being the default in the webback config so I could test for their existence in the deploy script.