### PR TITLE
refactor: add a common prefix for admin endpoint metrics

### DIFF
--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -61,12 +61,15 @@ def create_app():
             # do some massaging to get the metric name right
             # * get rid of the `/v2` prefix on v2 endpoints added by `base_path` further up
             # * remove various module prefixes
+            # * add a common prefix to ensure that we can mark these metrics as gauges for
+            #   statsd
             metric = (
                 request.url_rule.endpoint.removeprefix("/v2.")
                 .removeprefix("auslib_web_admin_views_")
                 .removeprefix("auslib_web_admin_")
                 .removeprefix("auslib_web_common_")
             )
+            metric = f"endpoint_{metric}"
             g.request_timer = statsd.timer(metric)
             g.request_timer.start()
 

--- a/tests/admin/views/test_releases_v2.py
+++ b/tests/admin/views/test_releases_v2.py
@@ -2161,31 +2161,31 @@ def test_set_older_pin_does_nothing(api):
         pytest.param(
             "GET",
             "/v2/releases",
-            "releases_v2_get_all",
+            "endpoint_releases_v2_get_all",
             id="get_all",
         ),
         pytest.param(
             "GET",
             "/v2/releases/Firefox-33.0-build1",
-            "releases_v2_get",
+            "endpoint_releases_v2_get",
             id="get",
         ),
         pytest.param(
             "POST",
             "/v2/releases/Firefox-33.0-build1",
-            "releases_v2_update",
+            "endpoint_releases_v2_update",
             id="update",
         ),
         pytest.param(
             "PUT",
             "/v2/releases/Firefox-33.0-build1",
-            "releases_v2_ensure",
+            "endpoint_releases_v2_ensure",
             id="ensure",
         ),
         pytest.param(
             "DELETE",
             "/v2/releases/Firefox-33.0-build1",
-            "releases_v2_delete",
+            "endpoint_releases_v2_delete",
             id="delete",
         ),
     ),
@@ -2211,7 +2211,7 @@ def test_statsd_gcs_creation(api, firefox_62_0_build1):
         # 21 * 2 = 42
         # plus 1 for the overall request
         assert mocked_timer.call_count == 43
-        mocked_timer.assert_has_calls([mock.call("async_gcs_upload"), mock.call("releases_v2_ensure")], any_order=True)
+        mocked_timer.assert_has_calls([mock.call("async_gcs_upload"), mock.call("endpoint_releases_v2_ensure")], any_order=True)
 
 
 @pytest.mark.usefixtures("releases_db", "mock_verified_userinfo")
@@ -2226,7 +2226,7 @@ def test_statsd_gcs_update(api):
         assert ret.status_code == 200, ret.data
         # one call for top level modification, one for the changed locale, one for overall request
         assert mocked_timer.call_count == 3
-        mocked_timer.assert_has_calls([mock.call("async_gcs_upload"), mock.call("releases_v2_update")], any_order=True)
+        mocked_timer.assert_has_calls([mock.call("async_gcs_upload"), mock.call("endpoint_releases_v2_update")], any_order=True)
 
 
 @pytest.mark.usefixtures("releases_db", "mock_verified_userinfo")
@@ -2237,4 +2237,4 @@ def test_statsd_gcs_delete(api):
 
         # one call for top level, one call for each locale, one for overall request
         assert mocked_timer.call_count == 22
-        mocked_timer.assert_has_calls([mock.call("async_gcs_upload"), mock.call("releases_v2_delete")], any_order=True)
+        mocked_timer.assert_has_calls([mock.call("async_gcs_upload"), mock.call("endpoint_releases_v2_delete")], any_order=True)

--- a/tests/admin/views/test_rules.py
+++ b/tests/admin/views/test_rules.py
@@ -572,25 +572,25 @@ class TestStatsd(ViewTest):
     def testGet(self, mocked_timer):
         self._get("/rules")
         assert mocked_timer.call_count == 1
-        mocked_timer.assert_has_calls([mock.call("rules_get")])
+        mocked_timer.assert_has_calls([mock.call("endpoint_rules_get")])
 
     @mock.patch("auslib.web.admin.base.statsd.timer")
     def testPost(self, mocked_timer):
         self._post("/rules", data=dict(backgroundRate=31, mapping="c", priority=33, product="Firefox", update_type="minor", channel="nightly"))
         assert mocked_timer.call_count == 1
-        mocked_timer.assert_has_calls([mock.call("rules_create")])
+        mocked_timer.assert_has_calls([mock.call("endpoint_rules_create")])
 
     @mock.patch("auslib.web.admin.base.statsd.timer")
     def testPut(self, mocked_timer):
         self._put("/rules/1", data=dict(backgroundRate=71, mapping="d", priority=73, data_version=1, product="Firefox", channel="nightly", update_type="minor"))
         assert mocked_timer.call_count == 1
-        mocked_timer.assert_has_calls([mock.call("rules_update_put")])
+        mocked_timer.assert_has_calls([mock.call("endpoint_rules_update_put")])
 
     @mock.patch("auslib.web.admin.base.statsd.timer")
     def testDelete(self, mocked_timer):
         self._delete("/rules/1", qs=dict(data_version=2))
         assert mocked_timer.call_count == 1
-        mocked_timer.assert_has_calls([mock.call("rules_delete")])
+        mocked_timer.assert_has_calls([mock.call("endpoint_rules_delete")])
 
 
 class TestSingleRuleView_JSON(ViewTest):


### PR DESCRIPTION
Not _strictly_ necessary, but it allows us to explicitly mark these as Gauges in statsd, which looks like it may be necessary to get them exported to Prometheus properly.