### PR TITLE
Replace clipboard-copy with native javascript

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,6 @@
     "axios": "^1.10.0",
     "change-case": "^4.1.2",
     "classnames": "^2.2.6",
-    "clipboard-copy": "^4.0.1",
     "codemirror": "^5.64.0",
     "date-fns": "2.26.0",
     "deep-sort-object": "^1.0.2",

--- a/ui/src/components/Dashboard/UserMenu.jsx
+++ b/ui/src/components/Dashboard/UserMenu.jsx
@@ -7,7 +7,6 @@ import MenuItem from '@material-ui/core/MenuItem';
 import IconButton from '@material-ui/core/IconButton';
 import LogoutVariantIcon from 'mdi-react/LogoutVariantIcon';
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon';
-import copy from 'clipboard-copy';
 import Button from '../Button';
 
 const useStyles = makeStyles(theme => ({
@@ -34,7 +33,7 @@ function UserMenu(props) {
   const handleCopyAccessToken = async () => {
     const accessToken = await auth0.getAccessTokenSilently();
 
-    copy(accessToken);
+    await navigator.clipboard.writeText(accessToken);
     handleMenuClose();
   };
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3054,11 +3054,6 @@ clean-webpack-plugin@^3.0.0:
     "@types/webpack" "^4.4.31"
     del "^4.1.1"
 
-clipboard-copy@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-4.0.1.tgz#326ef9726d4ffe72d9a82a7bbe19379de692017d"
-  integrity sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng==
-
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"


### PR DESCRIPTION
I don't think we need to support firefox < 63 or IE11... Pulling in a library for this is just unnecessary