### PR TITLE
Split out python lints into their own tasks

### DIFF
--- a/taskcluster/balrog_taskgraph/transforms/tox.py
+++ b/taskcluster/balrog_taskgraph/transforms/tox.py
@@ -11,10 +11,9 @@ transforms = TransformSequence()
 
 
 @transforms.add
-def update_env(config, jobs):
-    for job in jobs:
+def update_env(config, tasks):
+    for task in tasks:
         pr_number = config.params.get("pull_request_number", "")
-        env = job.pop("env", {})
+        env = task["worker"].setdefault("env", {})
         env["CI_PULL_REQUEST"] = str(pr_number)
-        job["worker"].setdefault("env", {}).update(env)
-        yield job
+        yield task

--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -12,7 +12,7 @@ transforms:
 task-defaults:
         run-on-tasks-for: [github-pull-request, github-push]
         attributes:
-          code-review: true
+            code-review: true
         worker-type: test
         worker:
             docker-image: {in-tree: 'python3.13'}
@@ -29,17 +29,19 @@ tasks:
         run:
             cwd: '{checkout}'
             command: 'taskcluster/scripts/get-coveralls-token tox'
-        env:
-            TOXENV: 'py313,coveralls'
+        worker:
+            env:
+                TOXENV: 'py313,coveralls'
         scopes:
             - secrets:get:repo:github.com/mozilla-releng/balrog:coveralls
 
     lint-backend:
       description: balrog backend lints
       run:
-        cwd: '{checkout}'
-      env:
-        TOXENV: 'check'
+          cwd: '{checkout}'
+      worker:
+          env:
+              TOXENV: 'check'
 
     agent:
         description: balrog agent tests
@@ -52,9 +54,10 @@ tasks:
     lint-agent:
       description: balrog agent lints
       run:
-        cwd: '{checkout}/agent'
-      env:
-        TOXENV: 'check'
+          cwd: '{checkout}/agent'
+      worker:
+          env:
+              TOXENV: 'check'
 
     client:
         description: balrog client tests
@@ -68,9 +71,10 @@ tasks:
     lint-client:
       description: balrog client lints
       run:
-        cwd: '{checkout}/client'
-      env:
-        TOXENV: 'check'
+          cwd: '{checkout}/client'
+      worker:
+          env:
+              TOXENV: 'check'
 
     client-py313:
         description: balrog client tests (python 3.13)


### PR DESCRIPTION
It's very annoying especially for the backend one to have to wait until the entire test suite finishes to know that you forgot a space before a comment and then haver to wait 10mn again...