### PR TITLE
Revert "Temporarily allow ciscobinarytest subdomain for balrog stage (#3486)"

### DIFF
--- a/uvicorn/admin.py
+++ b/uvicorn/admin.py
@@ -47,7 +47,6 @@ if STAGING or LOCALDEV:
     SYSTEM_ACCOUNTS.extend(["balrog-stage-ffxbld", "balrog-stage-tbirdbld", "balrog-stage-xpibld"])
     DOMAIN_ALLOWLIST.update(
         {
-            "ciscobinarytest.openh264.org": ("OpenH264",),  # TODO: Remove this (bug 1977228)
             "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild", "SystemAddons"),
             "bouncer-bouncer.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
             "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild"),

--- a/uvicorn/public.py
+++ b/uvicorn/public.py
@@ -47,7 +47,6 @@ DOMAIN_ALLOWLIST = {
 if STAGING or LOCALDEV:
     DOMAIN_ALLOWLIST.update(
         {
-            "ciscobinarytest.openh264.org": ("OpenH264",),  # TODO: Remove this (bug 1977228)
             "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
             "bouncer-bouncer.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
             "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),


### PR DESCRIPTION
This reverts commit 05f24115e1927e802b7fd3317908ce404ec18752.