### PR TITLE
Allow the ciscobinarytest domain on staging permanently

### DIFF
--- a/uvicorn/admin.py
+++ b/uvicorn/admin.py
@@ -47,7 +47,7 @@ if STAGING or LOCALDEV:
     SYSTEM_ACCOUNTS.extend(["balrog-stage-ffxbld", "balrog-stage-tbirdbld", "balrog-stage-xpibld"])
     DOMAIN_ALLOWLIST.update(
         {
-            "ciscobinarytest.openh264.org": ("OpenH264",),  # TODO: Remove this (bug 1977228)
+            "ciscobinarytest.openh264.org": ("OpenH264",),
             "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild", "SystemAddons"),
             "bouncer-bouncer.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
             "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird", "Pinebuild"),

--- a/uvicorn/public.py
+++ b/uvicorn/public.py
@@ -47,7 +47,7 @@ DOMAIN_ALLOWLIST = {
 if STAGING or LOCALDEV:
     DOMAIN_ALLOWLIST.update(
         {
-            "ciscobinarytest.openh264.org": ("OpenH264",),  # TODO: Remove this (bug 1977228)
+            "ciscobinarytest.openh264.org": ("OpenH264",),
             "ftp.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
             "bouncer-bouncer.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),
             "bouncer-bouncer-releng.stage.mozaws.net": ("Firefox", "Fennec", "Devedition", "SeaMonkey", "Thunderbird"),


### PR DESCRIPTION
After some discussion, we decided to make this permanent since it's likely to be needed again on the future and the config only applies to staging