### PR TITLE
Disable the overlay for react-refresh

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -236,7 +236,9 @@ module.exports = (_, { mode }) => {
         ignoreOrder: false,
         chunkFilename: 'assets/[name].[contenthash:8].css',
       }),
-      ...(mode === 'development' ? [new ReactRefreshWebpackPlugin()] : []),
+      ...(mode === 'development'
+        ? [new ReactRefreshWebpackPlugin({ overlay: false })]
+        : []),
     ],
     entry: {
       index: [`${__dirname}/src/index`],


### PR DESCRIPTION
I didn't realize that it had that feature and it's very annoying for balrog because it shows runtime errors which we get constantly on the releases page because of some 404s.