### PR TITLE
Allow HEAD requests from `allow_origins` too

### DIFF
--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -204,7 +204,7 @@ def create_app(allow_origins=None):
             MiddlewarePosition.BEFORE_ROUTING,
             allow_origins=allow_origins,
             allow_headers=["Authorization", "Content-Type"],
-            allow_methods=["OPTIONS", "GET", "POST", "PUT", "DELETE"],
+            allow_methods=["OPTIONS", "GET", "POST", "PUT", "DELETE", "HEAD"],
         )
 
     return connexion_app

--- a/tests/admin/views/test_base.py
+++ b/tests/admin/views/test_base.py
@@ -35,4 +35,4 @@ class TestJsonLogFormatter(ViewTest):
         options = self.client.options("/rules", headers={"Origin": "example.com", "Access-Control-Request-Method": "GET"})
         self.assertGreaterEqual({h.strip() for h in options.headers.get("Access-Control-Allow-Headers", "").split(",")}, {"Authorization", "Content-Type"})
         self.assertEqual(options.headers.get("Access-Control-Allow-Origin"), "*")
-        self.assertEqual(options.headers.get("Access-Control-Allow-Methods"), "OPTIONS, GET, POST, PUT, DELETE")
+        self.assertEqual(options.headers.get("Access-Control-Allow-Methods"), "OPTIONS, GET, POST, PUT, DELETE, HEAD")


### PR DESCRIPTION
We use HEAD requests from the user page and without this we get CORS rejections.