### PR TITLE
admin: don't send request body validation errors to sentry

### DIFF
--- a/src/auslib/web/admin/views/validators.py
+++ b/src/auslib/web/admin/views/validators.py
@@ -33,7 +33,7 @@ class BalrogRequestBodyValidator(RequestBodyValidator):
                 exception_message = exception_field + exception.message
             # Some exceptions could contain unicode characters - if we don't replace them
             # we could end up with a UnicodeEncodeError.
-            logger.error("{url} validation error: {error}".format(url=url, error=exception_message.encode("utf-8", "replace")))
+            logger.warning("{url} validation error: {error}".format(url=url, error=exception_message.encode("utf-8", "replace")))
             raise BadRequestProblem(detail=exception_message)
 
         return None


### PR DESCRIPTION
The sentry logging integration creates sentry events from error log entries, which creates false positives.