### PR TITLE
Update ramda

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,7 @@
     "mdi-react": "^8.2.0",
     "prop-types": "^15",
     "qs": "^6.10.1",
-    "ramda": "^0.27.1",
+    "ramda": "^0.31.3",
     "react": "^16.13.1",
     "react-codemirror2": "^7.2.1",
     "react-diff-view": "^2.4.7",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5950,10 +5950,10 @@ qs@^6.10.1:
   dependencies:
     side-channel "^1.0.4"
 
-ramda@^0.27.1:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
-  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
+ramda@^0.31.3:
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.31.3.tgz#0f54199ec99a7bd6702277d28d6bf7f93b916bb9"
+  integrity sha512-xKADKRNnqmDdX59PPKLm3gGmk1ZgNnj3k7DryqWwkamp4TJ6B36DdpyKEQ0EoEYmH2R62bV4Q+S0ym2z8N2f3Q==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
AFAICT none of the breaking change between 0.27 and 0.31 affect any of the function we use. I tested a bunch of paths that are using said functions and couldn't find any issue.