### PR TITLE
Remove the engine limit in packages.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
-  "engines": {
-    "node": ">=18.0.0 <19.0.0"
-  },
   "scripts": {
     "build": "webpack --mode production",
     "start": "webpack-dev-server --mode development",


### PR DESCRIPTION
I'm tired of removing it every time I want to run yarn locally. IMO this doesn't provide anything as this isn't a library and the version that matters is the one that builds it in the docker container, and that isn't going to magically become incompatible