### PR TITLE
Replace react-virtualized by tanstack/react-virtual

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -14,8 +14,6 @@
     "lint:ci": "biome ci"
   },
   "comment": "IMPORTANT! date-fns is pinned to 1.3.x due to https://github.com/mui-org/material-ui-pickers/issues/1440",
-  "comment2": "IMPORTANT! react-virtualized is held at 9.21.1 due to https://github.com/bvaughn/react-virtualized/issues/1226 breaking scrolling to anchors on ListRules",
-  "comment3": "see also https://github.com/bvaughn/react-virtualized/issues/1179#issuecomment-572854217",
   "dependencies": {
     "@auth0/auth0-react": "^2.3.0",
     "@date-io/date-fns": "^1.3.13",
@@ -43,7 +41,8 @@
     "react-helmet": "^6.1.0",
     "react-number-format": "^5.4.4",
     "react-router-dom": "^5.2.0",
-    "react-virtualized": "9.21.1"
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.12"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",

--- a/ui/src/views/Releases/ListReleaseRevisions/index.jsx
+++ b/ui/src/views/Releases/ListReleaseRevisions/index.jsx
@@ -1,13 +1,11 @@
 import Box from '@material-ui/core/Box';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import axios from 'axios';
-import React, { Fragment, useEffect, useState } from 'react';
-import { Column } from 'react-virtualized';
-import 'react-virtualized/styles.css';
 import Drawer from '@material-ui/core/Drawer';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/styles';
+import axios from 'axios';
 import { formatDistanceStrict } from 'date-fns';
+import React, { Fragment, useEffect, useState } from 'react';
 import Button from '../../../components/Button';
 import Dashboard from '../../../components/Dashboard';
 import DiffRelease from '../../../components/DiffRelease';
@@ -119,6 +117,58 @@ function ListReleaseRevisions(props) {
   const revisionsCount = revisions.length;
   const columnWidth = CONTENT_MAX_WIDTH / 4;
 
+  const columns = React.useMemo(() => [
+    {
+      accessorKey: 'timestamp',
+      cell: ({ cell }) =>
+        formatDistanceStrict(new Date(cell.getValue()), new Date(), {
+          addSuffix: true,
+        }),
+      header: 'Revision Date',
+      width: columnWidth,
+    },
+    {
+      header: 'Changed By',
+      accessorKey: 'changed_by',
+      width: columnWidth,
+    },
+    {
+      header: 'Compare',
+      accessorKey: 'compare',
+      width: columnWidth,
+      cell: ({ row }) => (
+        <Fragment>
+          <Radio
+            variant="red"
+            value={row.index}
+            disabled={row.index === 0}
+            checked={leftRadioCheckedIndex === row.index}
+            onChange={handleLeftRadioChange}
+          />
+          <Radio
+            variant="green"
+            value={row.index}
+            disabled={row.index === revisions.length - 1}
+            checked={rightRadioCheckedIndex === row.index}
+            onChange={handleRightRadioChange}
+          />
+        </Fragment>
+      ),
+    },
+    {
+      id: 'actions',
+      width: columnWidth,
+      cell: ({ row }) => (
+        <Fragment>
+          <Button onClick={handleViewClick(row.original)}>View</Button>
+          {row.index > 0 && (
+            <Button onClick={handleRestoreClick}>Restore</Button>
+          )}
+        </Fragment>
+      ),
+    },
+  ]);
+
   return (
     <Dashboard title={`Release ${releaseName} Revisions`}>
       {error && <ErrorPanel error={error} />}
@@ -132,61 +182,7 @@ function ListReleaseRevisions(props) {
       )}
       {!isLoading && revisionsCount > 1 && (
         <Fragment>
-          <RevisionsTable
-            rowCount={revisionsCount}
-            rowGetter={({ index }) => revisions[index]}
-          >
-            <Column
-              label="Revision Date"
-              dataKey="timestamp"
-              cellRenderer={({ cellData }) =>
-                formatDistanceStrict(new Date(cellData), new Date(), {
-                  addSuffix: true,
-                })
-              }
-              width={columnWidth}
-            />
-            <Column
-              width={columnWidth}
-              label="Changed By"
-              dataKey="changed_by"
-            />
-            <Column
-              label="Compare"
-              dataKey="compare"
-              width={columnWidth}
-              cellRenderer={({ rowIndex }) => (
-                <Fragment>
-                  <Radio
-                    variant="red"
-                    value={rowIndex}
-                    disabled={rowIndex === 0}
-                    checked={leftRadioCheckedIndex === rowIndex}
-                    onChange={handleLeftRadioChange}
-                  />
-                  <Radio
-                    variant="green"
-                    value={rowIndex}
-                    disabled={rowIndex === revisions.length - 1}
-                    checked={rightRadioCheckedIndex === rowIndex}
-                    onChange={handleRightRadioChange}
-                  />
-                </Fragment>
-              )}
-            />
-            <Column
-              dataKey="actions"
-              width={columnWidth}
-              cellRenderer={({ rowData, rowIndex }) => (
-                <Fragment>
-                  <Button onClick={handleViewClick(rowData)}>View</Button>
-                  {rowIndex > 0 && (
-                    <Button onClick={handleRestoreClick}>Restore</Button>
-                  )}
-                </Fragment>
-              )}
-            />
-          </RevisionsTable>
+          <RevisionsTable data={revisions} columns={columns} />
           {leftRevisionData && rightRevisionData && (
             <DiffRelease
               className={classes.jsDiff}

--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -13,7 +13,14 @@ import { makeStyles, useTheme } from '@material-ui/styles';
 import classNames from 'classnames';
 import PlusIcon from 'mdi-react/PlusIcon';
 import { clone } from 'ramda';
-import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  Fragment,
+  forwardRef,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import Dashboard from '../../../components/Dashboard';
 import DialogAction from '../../../components/DialogAction';
 import DiffRelease from '../../../components/DiffRelease';
@@ -474,10 +481,6 @@ function ListReleases(props) {
       }),
     );
 
-    if (result.sc) {
-      releaseListRef.current.recomputeRowHeights();
-    }
-
     handleDialogClose();
   };
 
@@ -707,12 +710,12 @@ function ListReleases(props) {
     }
   };
 
-  const Row = ({ index, style }) => {
+  const Row = forwardRef(({ index, style }, ref) => {
     const release = filteredReleases[index];
     const isSelected = Boolean(hash && hash.replace('#', '') === release.name);
 
     return (
-      <div key={release.name} style={style}>
+      <div style={style} data-index={index} ref={ref}>
         <ReleaseCard
           className={classNames(classes.releaseCard, {
             [classes.releaseCardSelected]: isSelected,
@@ -728,9 +731,9 @@ function ListReleases(props) {
         />
       </div>
     );
-  };
+  });
 
-  const getRowHeight = ({ index }) => {
+  const getRowHeight = (index) => {
     const listItemTextMargin = 6;
     const release = filteredReleases[index];
     // An approximation
@@ -842,7 +845,7 @@ function ListReleases(props) {
       {!isLoading && filteredReleases && (
         <VariableSizeList
           ref={releaseListRef}
-          rowRenderer={Row}
+          Row={Row}
           scrollToRow={scrollToRow}
           rowHeight={getRowHeight}
           rowCount={filteredReleasesCount}

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -25,7 +25,14 @@ import PauseIcon from 'mdi-react/PauseIcon';
 import PlusIcon from 'mdi-react/PlusIcon';
 import { parse, stringify } from 'qs';
 import { clone } from 'ramda';
-import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  Fragment,
+  forwardRef,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import Dashboard from '../../../components/Dashboard';
 import DateTimePicker from '../../../components/DateTimePicker';
 import DialogAction from '../../../components/DialogAction';
@@ -319,7 +326,6 @@ function ListRules(props) {
 
   const handleRewindDiffChange = ({ target: { checked: value } }) => {
     setShowRewindDiff(value);
-    ruleListRef.current.recomputeRowHeights();
   };
 
   const handleSnackbarClose = (_event, reason) => {
@@ -595,7 +601,6 @@ function ListRules(props) {
           return newRule;
         }),
       );
-      ruleListRef.current.recomputeRowHeights();
       handleSnackbarOpen({
         message: `Rule ${result.rule_id} successfully scheduled`,
       });
@@ -1158,7 +1163,7 @@ function ListRules(props) {
     return dialogStates[dialogState.mode];
   };
 
-  const getRowHeight = ({ index }) => {
+  const getRowHeight = (index) => {
     const rule = filteredRulesWithScheduledChanges[index];
     const currentRule = rulesWithScheduledChanges.find(
       (r) => r.rule_id === rule.rule_id,
@@ -1332,7 +1337,7 @@ function ListRules(props) {
     }
   };
 
-  const Row = ({ index, style }) => {
+  const Row = forwardRef(({ index, style }, ref) => {
     // if we're in rewind mode, rule is a historical rule, not the current one
     const rule = filteredRulesWithScheduledChanges[index];
     const isSelected = isRuleSelected(rule);
@@ -1342,6 +1347,8 @@ function ListRules(props) {
 
     return (
       <div
+        data-index={index}
+        ref={ref}
         key={
           rule.rule_id
             ? rule.rule_id
@@ -1373,7 +1380,7 @@ function ListRules(props) {
         />
       </div>
     );
-  };
+  });
 
   useEffect(() => {
     if (filteredRulesCount) {
@@ -1507,12 +1514,10 @@ function ListRules(props) {
               <Fragment>
                 <VariableSizeList
                   ref={ruleListRef}
-                  rowRenderer={Row}
+                  Row={Row}
                   scrollToRow={scrollToRow}
                   rowHeight={getRowHeight}
                   rowCount={filteredRulesCount}
-                  searchFieldHeight={searchFieldHeight}
-                  pathname={props.location.pathname}
                 />
               </Fragment>
             ) : (

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1613,6 +1613,30 @@
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
+"@tanstack/react-table@^8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.21.3.tgz#2c38c747a5731c1a07174fda764b9c2b1fb5e91b"
+  integrity sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==
+  dependencies:
+    "@tanstack/table-core" "8.21.3"
+
+"@tanstack/react-virtual@^3.13.12":
+  version "3.13.12"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz#d372dc2783739cc04ec1a728ca8203937687a819"
+  integrity sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==
+  dependencies:
+    "@tanstack/virtual-core" "3.13.12"
+
+"@tanstack/table-core@8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
+  integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
+
+"@tanstack/virtual-core@3.13.12":
+  version "3.13.12"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz#1dff176df9cc8f93c78c5e46bcea11079b397578"
+  integrity sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==
+
 "@tybys/wasm-util@^0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.0.tgz#2fd3cd754b94b378734ce17058d0507c45c88369"
@@ -2427,14 +2451,6 @@ babel-preset-jest@30.0.1:
     babel-plugin-jest-hoist "30.0.1"
     babel-preset-current-node-syntax "^1.1.0"
 
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -2699,7 +2715,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.0.1, clsx@^1.0.2, clsx@^1.0.4:
+clsx@^1.0.2, clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -2836,11 +2852,6 @@ core-js-pure@^3.23.3:
   version "3.44.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.44.0.tgz#6e9d6c128c8b967c5eac4f181c2b654d85c28090"
   integrity sha512-gvMQAGB4dfVUxpYD0k3Fq8J+n5bB6Ytl15lqlZrOIXFzxOhtPaObfkQGHtMRdyjIf7z2IeNULwi1jEwyS+ltKQ==
-
-core-js@^2.4.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -3044,13 +3055,6 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-"dom-helpers@^2.4.0 || ^3.0.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -4610,11 +4614,6 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-linear-layout-vector@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/linear-layout-vector/-/linear-layout-vector-0.0.1.tgz#398114d7303b6ecc7fd6b273af7b8401d8ba9c70"
-  integrity sha512-w+nr1ZOVFGyMhwr8JKo0YzqDc8C2Z7pc9UbTuJA4VG/ezlSFEx+7kNrfCYvq7JQ/jHKR+FWy6reNrkVVzm0hSA==
-
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -4663,7 +4662,7 @@ lodash@^4.17.20, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5206,7 +5205,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-prop-types@^15, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -5339,11 +5338,6 @@ react-is@^18.3.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
 react-number-format@^5.4.4:
   version "5.4.4"
   resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.4.4.tgz#d31f0e260609431500c8d3f81bbd3ae1fb7cacad"
@@ -5397,19 +5391,6 @@ react-transition-group@^4.0.0, react-transition-group@^4.4.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-virtualized@9.21.1:
-  version "9.21.1"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.1.tgz#4dbbf8f0a1420e2de3abf28fbb77120815277b3a"
-  integrity sha512-E53vFjRRMCyUTEKuDLuGH1ld/9TFzjf/fFW816PE4HFXWZorESbSTYtiZz1oAjra0MminaUU1EnvUxoGuEFFPA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    clsx "^1.0.1"
-    dom-helpers "^2.4.0 || ^3.0.0"
-    linear-layout-vector "0.0.1"
-    loose-envify "^1.3.0"
-    prop-types "^15.6.0"
-    react-lifecycles-compat "^3.0.4"
 
 react@^16.13.1:
   version "16.14.0"
@@ -5467,11 +5448,6 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"


### PR DESCRIPTION
react-virtualized had some bug with anchors that prevented us from updating it. That bug has never been fixed, and the author seems to have moved onto a third rewrite of it since we last updated. If we were going to replace it by a rewrite, we might as well try something else, tanstack/react-virtual seems to be what people use these days and it seems to work very well with our stuff. The update wasn't exactly straightforward as tanstack forces you to handle a bit more yourself that react-virtualized ever did, but in the end it works as well as before and even before in some cases:

- the releases list used to have the gap triple in the middle for some reason, this does not happen anymore.
- We're now using a table for tables instead of the div soup that react-virtualized was using. While the visual output doesn't change, I feel a lot better about that...

### After / Before

<img width="2540" height="1123" alt="image" src="https://github.com/user-attachments/assets/d6585781-fcda-4e08-9aff-e0ff670e61c8" />
<img width="2543" height="862" alt="image" src="https://github.com/user-attachments/assets/65bf9989-7b61-4204-8ee3-a61711e8b08c" />
<img width="2553" height="551" alt="image" src="https://github.com/user-attachments/assets/29b27a31-3a64-4be9-a00e-600cafc5ad1e" />
<img width="2546" height="776" alt="image" src="https://github.com/user-attachments/assets/37119211-3285-4d2d-be3a-a5f4c1254ace" />
<img width="2547" height="773" alt="image" src="https://github.com/user-attachments/assets/0c52af41-8cdf-4e25-8ed3-19e1a48a3762" />
<img width="2561" height="999" alt="image" src="https://github.com/user-attachments/assets/d49558bd-588a-4e4a-b2df-134334df1116" />
