### PR TITLE
Ignore errors from `getAccessTokenSilently`

### DIFF
--- a/ui/src/Main.jsx
+++ b/ui/src/Main.jsx
@@ -38,9 +38,14 @@ function setupAxiosInterceptors(getAccessTokenSilently, getIdTokenClaims) {
       const claims = await getIdTokenClaims();
 
       if (claims) {
-        const accessToken = await getAccessTokenSilently();
+        try {
+          const accessToken = await getAccessTokenSilently();
 
-        result.headers.Authorization = `Bearer ${accessToken}`;
+          result.headers.Authorization = `Bearer ${accessToken}`;
+        } catch {
+          // Do nothing on purpose here. If `getAccessTokenSilently`, it will log the user out but we don't want that erro
+          // to bubble out of here as it would be shown to the user as a "are you sure you're connected to the VPN"
+        }
       }
     }
 

--- a/ui/src/Main.jsx
+++ b/ui/src/Main.jsx
@@ -43,7 +43,7 @@ function setupAxiosInterceptors(getAccessTokenSilently, getIdTokenClaims) {
 
           result.headers.Authorization = `Bearer ${accessToken}`;
         } catch {
-          // Do nothing on purpose here. If `getAccessTokenSilently`, it will log the user out but we don't want that erro
+          // Do nothing on purpose here. If `getAccessTokenSilently`, it will log the user out but we don't want that error
           // to bubble out of here as it would be shown to the user as a "are you sure you're connected to the VPN"
         }
       }


### PR DESCRIPTION
We cannot do anything about those and they will log the user out which will prevent the call from failing again (as it'll reset the claim token). If we don't ignore it, it logs the user out anyway but also shows a "Are you sure you're connected to the VPN" error.

This is way easier than what I did in shipit because all API requests in balrog are authenticated including the `__heartbeat__` so we can just use the fact that the heartbeat tries to get a token before actually calling the route to check for the token on load