### PR TITLE
blobs: treat empty `pin` query parameter as if it weren't there

### DIFF
--- a/src/auslib/blobs/apprelease.py
+++ b/src/auslib/blobs/apprelease.py
@@ -234,7 +234,7 @@ class ReleaseBlobBase(XMLBlob):
             return ServeUpdate.No
 
         version_pin = updateQuery.get("pin")
-        if version_pin is not None:
+        if version_pin:
             try:
                 version_pin = PinVersion(version_pin)
             except ValueError:

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -2911,3 +2911,16 @@ class ClientTestPinning(ClientTestCommon):
 </update>
 </updates>""",
         )
+
+    def testEmptyPin(self):
+        # An empty pin param is ignored
+        ret = self.client.get("/update/6/b/1.0/30000101000010/p/l/c/a/a/a/a/update.xml?pin=")
+        self.assertUpdateTextEqual(
+            ret,
+            """<?xml version="1.0"?>
+<updates>
+    <update type="minor" version="3.0" extensionVersion="3.0" buildID="30000101000030">
+        <patch type="complete" URL="http://a.com/3" hashFunction="sha512" hashValue="4" size="3"/>
+    </update>
+</updates>""",
+        )


### PR DESCRIPTION
`PinVersion("")` doesn't raise but returns a broken object, so we'd otherwise break later on when trying to compare with a blob's version.

Fixes #3530