### PR TITLE
docker: use python:3.13-slim-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # WARNING: keep this file in sync with taskcluster/docker/balrog-backend/Dockerfile
 
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
 
 ENV LC_ALL C.UTF-8
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,6 +1,6 @@
 # WARNING: keep this file in sync with taskcluster/docker/balrog-agent/Dockerfile
 
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
 
 MAINTAINER jcristau@mozilla.com
 

--- a/agent/Dockerfile.test
+++ b/agent/Dockerfile.test
@@ -1,6 +1,6 @@
 # WARNING: keep this file in sync with taskcluster/docker/balrog-agent/Dockerfile
 
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
 
 MAINTAINER jcristau@mozilla.com
 

--- a/taskcluster/docker/balrog-agent/Dockerfile
+++ b/taskcluster/docker/balrog-agent/Dockerfile
@@ -1,6 +1,6 @@
 # WARNING: keep this file in sync with agent/Dockerfile
 
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
 
 MAINTAINER jcristau@mozilla.com
 

--- a/taskcluster/docker/balrog-backend/Dockerfile
+++ b/taskcluster/docker/balrog-backend/Dockerfile
@@ -1,6 +1,6 @@
 # WARNING: keep this file in sync with the main balrog Dockerfile
 
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
 
 ENV LC_ALL C.UTF-8
 


### PR DESCRIPTION
The python:3.13-slim image is now based on debian 13 (trixie) instead of 12 (bookworm); go back to the older distro for now to prevent breakage.