### PR TITLE
web: reject empty `pin` query parameter

### DIFF
--- a/src/auslib/web/public/swagger/api.yml
+++ b/src/auslib/web/public/swagger/api.yml
@@ -361,3 +361,4 @@ parameters:
     description: pin
     required: false
     type: string
+    minLength: 1

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -2911,3 +2911,8 @@ class ClientTestPinning(ClientTestCommon):
 </update>
 </updates>""",
         )
+
+    def testEmptyPin(self):
+        # An empty pin param is rejected
+        ret = self.client.get("/update/6/b/1.0/30000101000010/p/l/c/a/a/a/a/update.xml?pin=")
+        self.assertEqual(ret.status_code, 400)


### PR DESCRIPTION
This causes breakage down the line because we parse it to an invalid PinVersion object.

Fixes #3530

This is a possibly more conservative alternative to #3531.