### PR TITLE
Add `version` back into the decision task parameters

### DIFF
--- a/taskcluster/balrog_taskgraph/__init__.py
+++ b/taskcluster/balrog_taskgraph/__init__.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+import tomllib
 from importlib import import_module
 
 from taskgraph.parameters import extend_parameters_schema
@@ -34,6 +35,13 @@ def _import_modules(modules):
 
 
 def get_decision_parameters(graph_config, parameters):
+    # Read version from pyproject.toml
+    version_file = os.path.join(graph_config.vcs_root, "pyproject.toml")
+    with open(version_file, "rb") as fd:
+        data = tomllib.load(fd)
+        version = data["project"]["version"]
+    parameters["version"] = version
+
     # Environment is defined in .taskcluster.yml
     pr_number = os.environ.get("BALROG_PULL_REQUEST_NUMBER", None)
     if not pr_number:


### PR DESCRIPTION
I was today years old when I learned that taskgraph was reading `version.txt` if it existed and putting it into the decision task parameters. Of course I missed that in #3529 which broke releases with `Exception: Version numbers in pyproject.toml (None) and release tag (3.87) don't match`. This should restore the previous behavior by extracting the version from `pyproject.toml` instead.