### PR TITLE
Replace react-router-dom with react-dom

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "react-diff-view": "^3.3.2",
     "react-dom": "^19",
     "react-number-format": "^5.4.4",
-    "react-router-dom": "7.8.1",
+    "react-router": "^7.8.2",
     "tss-react": "^4.9.19"
   },
   "devDependencies": {

--- a/ui/src/Main.jsx
+++ b/ui/src/Main.jsx
@@ -1,7 +1,7 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import axios from 'axios';
 import React, { Suspense, useEffect, useState } from 'react';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import Dashboard from './components/Dashboard';
 import ErrorPanel from './components/ErrorPanel';
 import routes from './routes';

--- a/ui/src/components/Dashboard/SettingsMenu.jsx
+++ b/ui/src/components/Dashboard/SettingsMenu.jsx
@@ -4,7 +4,7 @@ import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import React, { Fragment, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import Link from '../../utils/Link';
 import menuItems from './menuItems';

--- a/ui/src/components/Dashboard/index.jsx
+++ b/ui/src/components/Dashboard/index.jsx
@@ -3,7 +3,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { bool, node, string } from 'prop-types';
 import React, { Fragment } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import { APP_BAR_HEIGHT, CONTENT_MAX_WIDTH } from '../../utils/constants';
 import Link from '../../utils/Link';

--- a/ui/src/utils/Link.jsx
+++ b/ui/src/utils/Link.jsx
@@ -1,11 +1,11 @@
 import { bool } from 'prop-types';
 import React, { useState } from 'react';
-import { NavLink, Link as RouterLink } from 'react-router-dom';
+import { NavLink, Link as RouterLink } from 'react-router';
 import routes from '../routes';
 import matchRoutes from './matchRoutes';
 
 /**
- * A react hook which augments `react-router-dom`'s `Link` component
+ * A react hook which augments `react-router`'s `Link` component
  * with pre-fetching capabilities.
  */
 export default function Link({ viewName, nav, to, ...props }) {
@@ -64,7 +64,7 @@ export default function Link({ viewName, nav, to, ...props }) {
 
 Link.propTypes = {
   /**
-   * If true, the `NavLink` component of `react-router-dom` will be used
+   * If true, the `NavLink` component of `react-router` will be used
    * as the main link component.
    */
   nav: bool,

--- a/ui/src/utils/matchRoutes.js
+++ b/ui/src/utils/matchRoutes.js
@@ -1,4 +1,4 @@
-import { matchPath } from 'react-router-dom';
+import { matchPath } from 'react-router';
 
 // Returns an array of matched routes.
 const matchRoutes = (path, routes, branch = []) => {

--- a/ui/src/views/Releases/ListReleaseRevisions/index.jsx
+++ b/ui/src/views/Releases/ListReleaseRevisions/index.jsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import axios from 'axios';
 import { formatDistanceStrict } from 'date-fns';
 import React, { Fragment, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import Button from '../../../components/Button';
 import Dashboard from '../../../components/Dashboard';

--- a/ui/src/views/Releases/ListReleaseRevisionsV2/index.jsx
+++ b/ui/src/views/Releases/ListReleaseRevisionsV2/index.jsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import axios from 'axios';
 import { formatDistanceStrict } from 'date-fns';
 import React, { Fragment, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import Button from '../../../components/Button';
 import Dashboard from '../../../components/Dashboard';

--- a/ui/src/views/Releases/ListReleases/index.jsx
+++ b/ui/src/views/Releases/ListReleases/index.jsx
@@ -21,7 +21,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import Dashboard from '../../../components/Dashboard';
 import DialogAction from '../../../components/DialogAction';

--- a/ui/src/views/Releases/Release/index.jsx
+++ b/ui/src/views/Releases/Release/index.jsx
@@ -9,7 +9,7 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import classNames from 'classnames';
 import React, { Fragment, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';

--- a/ui/src/views/Releases/ReleaseV2/index.jsx
+++ b/ui/src/views/Releases/ReleaseV2/index.jsx
@@ -9,7 +9,7 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import classNames from 'classnames';
 import React, { Fragment, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';

--- a/ui/src/views/Releases/index.jsx
+++ b/ui/src/views/Releases/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import routes from './routes';
 
 export default function Releases(props) {

--- a/ui/src/views/RequiredSignoffs/ListSignoffs/index.jsx
+++ b/ui/src/views/RequiredSignoffs/ListSignoffs/index.jsx
@@ -16,7 +16,7 @@ import classNames from 'classnames';
 import { parse, stringify } from 'qs';
 import { clone, lensPath, view } from 'ramda';
 import React, { Fragment, useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import Dashboard from '../../../components/Dashboard';
 import DialogAction from '../../../components/DialogAction';

--- a/ui/src/views/RequiredSignoffs/ViewSignoff/index.jsx
+++ b/ui/src/views/RequiredSignoffs/ViewSignoff/index.jsx
@@ -18,7 +18,7 @@ import classNames from 'classnames';
 import { bool } from 'prop-types';
 import React, { Fragment, useEffect, useState } from 'react';
 import { NumericFormat } from 'react-number-format';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';

--- a/ui/src/views/RequiredSignoffs/index.jsx
+++ b/ui/src/views/RequiredSignoffs/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import routes from './routes';
 
 export default function Rules(props) {

--- a/ui/src/views/Roles/ListRoles/index.jsx
+++ b/ui/src/views/Roles/ListRoles/index.jsx
@@ -8,7 +8,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { parse, stringify } from 'qs';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import Dashboard from '../../../components/Dashboard';
 import ErrorPanel from '../../../components/ErrorPanel';

--- a/ui/src/views/Roles/index.jsx
+++ b/ui/src/views/Roles/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import routes from './routes';
 
 export default function Roles(props) {

--- a/ui/src/views/Rules/ListRuleRevisions/index.jsx
+++ b/ui/src/views/Rules/ListRuleRevisions/index.jsx
@@ -6,7 +6,7 @@ import { formatDistanceStrict } from 'date-fns';
 import { stringify } from 'qs';
 import { clone } from 'ramda';
 import React, { Fragment, useEffect, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import Button from '../../../components/Button';
 import Dashboard from '../../../components/Dashboard';

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -33,7 +33,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import Dashboard from '../../../components/Dashboard';
 import DateTimePicker from '../../../components/DateTimePicker';

--- a/ui/src/views/Rules/Rule/index.jsx
+++ b/ui/src/views/Rules/Rule/index.jsx
@@ -15,7 +15,7 @@ import { stringify } from 'qs';
 import { assocPath, defaultTo, pick } from 'ramda';
 import React, { Fragment, useEffect, useState } from 'react';
 import { NumericFormat } from 'react-number-format';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';

--- a/ui/src/views/Rules/index.jsx
+++ b/ui/src/views/Rules/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import routes from './routes';
 
 export default function Rules(props) {

--- a/ui/src/views/Users/ViewUser/index.jsx
+++ b/ui/src/views/Users/ViewUser/index.jsx
@@ -13,7 +13,7 @@ import Typography from '@mui/material/Typography';
 import { bool } from 'prop-types';
 import { clone, defaultTo, propOr } from 'ramda';
 import React, { Fragment, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 import AutoCompleteText from '../../../components/AutoCompleteText';
 import getSuggestions from '../../../components/AutoCompleteText/getSuggestions';

--- a/ui/src/views/Users/index.jsx
+++ b/ui/src/views/Users/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import routes from './routes';
 
 export default function Users(props) {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5351,17 +5351,10 @@ react-refresh@^0.17.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
-react-router-dom@7.8.1:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.8.1.tgz#9b5fedaf1886362ab02c9e4c51bc6afcd03151a0"
-  integrity sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==
-  dependencies:
-    react-router "7.8.1"
-
-react-router@7.8.1:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.8.1.tgz#62d62bc1a3fcde79c3ced8f7114f7b4f86916ce2"
-  integrity sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==
+react-router@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.8.2.tgz#9d2d4147ca72832c550acc60ed688062d18f70b8"
+  integrity sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==
   dependencies:
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"


### PR DESCRIPTION
The former is a legacy dependency that is just reexporting the latter for convenience and upgrade path smoothing. And I kinda forgot to remove it when I migrated us to react 19.