### PR TITLE
Pass the state correctly to the `Link` component

### DIFF
--- a/ui/src/components/RuleCard/index.jsx
+++ b/ui/src/components/RuleCard/index.jsx
@@ -338,10 +338,8 @@ function RuleCard({
           action={
             !readOnly ? (
               <Link
-                to={{
-                  pathname: `/rules/${rule.rule_id}/revisions`,
-                  state: { rulesFilter },
-                }}
+                to={`/rules/${rule.rule_id}/revisions`}
+                state={{ rulesFilter }}
               >
                 <Tooltip title="Revisions">
                   <IconButton size="large">
@@ -871,14 +869,12 @@ function RuleCard({
           ) : (
             <Link
               className={classes.link}
-              to={{
-                pathname: rule.rule_id
+              to={
+                rule.rule_id
                   ? `/rules/duplicate/ruleId/${rule.rule_id}`
-                  : `/rules/duplicate/scId/${rule.scheduledChange.sc_id}`,
-                state: {
-                  rulesFilter,
-                },
-              }}
+                  : `/rules/duplicate/scId/${rule.scheduledChange.sc_id}`
+              }
+              state={{ rulesFilter }}
             >
               <Button color="secondary">Duplicate</Button>
             </Link>
@@ -890,14 +886,12 @@ function RuleCard({
           ) : (
             <Link
               className={classes.link}
-              to={{
-                pathname: rule.rule_id
+              to={
+                rule.rule_id
                   ? `/rules/${rule.rule_id}`
-                  : `/rules/create/${rule.scheduledChange.sc_id}`,
-                state: {
-                  rulesFilter,
-                },
-              }}
+                  : `/rules/create/${rule.scheduledChange.sc_id}`
+              }
+              state={{ rulesFilter }}
             >
               <Button color="secondary">Update</Button>
             </Link>

--- a/ui/src/utils/Link.jsx
+++ b/ui/src/utils/Link.jsx
@@ -9,8 +9,7 @@ import matchRoutes from './matchRoutes';
  * with pre-fetching capabilities.
  */
 export default function Link({ viewName, nav, to, ...props }) {
-  const path = typeof to === 'string' ? to : to.pathname;
-  const isPathAbsolute = URL.canParse(path);
+  const isPathAbsolute = URL.canParse(to);
   const Component = nav ? NavLink : RouterLink;
   const [prefetchFlag, setPrefetchFlag] = useState(false);
 
@@ -20,7 +19,7 @@ export default function Link({ viewName, nav, to, ...props }) {
     }
 
     if (!isPathAbsolute) {
-      const matchingRoutes = matchRoutes(path, routes);
+      const matchingRoutes = matchRoutes(to, routes);
 
       matchingRoutes.forEach(({ component }) => {
         component.preload();

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -1570,12 +1570,7 @@ function ListRules(props) {
       </Drawer>
       <Snackbar onClose={handleSnackbarClose} {...snackbarState} />
       {!rewindDate && (
-        <Link
-          to={{
-            pathname: '/rules/create',
-            state: { rulesFilter: productChannelQueries },
-          }}
-        >
+        <Link to="/rules/create" state={{ rulesFilter: productChannelQueries }}>
           <Tooltip title="Add Rule">
             <Fab color="primary" className={classes.fab} disabled={rewindDate}>
               <AddIcon />


### PR DESCRIPTION
This fixes a regression from c3f865c7229f128fb99de73e66891f76d918ff4e where updating react-router silently broke keeping some state across navigation. The issue is that react router's API changed the state property from being nested within the `to` object to being directly on the routing components and the `to` component becoming a string. We didn't see this at all because of the `Link` wrapper that was doing some massaging on the `to` property when it wasn't a string, so we were just silently discarding the state parameter.

I removed said massaging to since we're passing strings to `to` everywhere now as we should.

Fixes #3547