### PR TITLE
chore: version bump 3.90

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "balrog"
-version = "3.89"
+version = "3.90"
 description = "Mozilla's Update Server"
 license = "MPL-2.0"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "balrog"
-version = "3.89"
+version = "3.90"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Forgot to do this after the last Github release 