### PR TITLE
Set auth0 sessionCheckExpiryDays to 7 days to match the token expiry

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -41,6 +41,7 @@ const App = () => {
           }}
           leeway={30}
           cacheLocation="localstorage"
+          sessionCheckExpiryDays={7}
         >
           <Main />
         </Auth0Provider>


### PR DESCRIPTION
When authenticating through auth0, we get a token that is valid for 7 days. We cannot refresh that token but after
ce2e38decb79915ad50fd3a304d97d65ff83744d, we started validating it.

During validation, the auth0 library checks the
`auth0.{...}.is.authenticated` cookie to verify that you're authed to auth0 itself on top of validating that the JWT hasn't expired. By default that cookie is only valid for a day so it would expire way before the JWT, leading to the check thinking that said JWT had expired, leading to the user getting logged out.

By matching the length of the JWT expiry and the `is.authenticated`, we're hopefully only going to be logged out once a week instead of once a day.