### PR TITLE
Parse Firefox VPN versions using StrictVersion

### DIFF
--- a/src/auslib/util/versions.py
+++ b/src/auslib/util/versions.py
@@ -153,6 +153,16 @@ class LooseVersion(Version):
             return 1
 
 
+def FirefoxVPNVersion(version):
+    """
+    Versions of FirefoxVPN are x.y.z, except some old versions that are x.y.
+    """
+    try:
+        return StrictVersion(version)
+    except ValueError:
+        raise BadDataError(f"Invalid app version {version}")
+
+
 class PostModernMozillaVersion(StrictVersion):
     """A version class that supports Firefox versions 5.0 and up, which
     may have "a1" but not "b2" tags in them"""
@@ -242,8 +252,8 @@ def MozillaVersion(version):
                 return ModernMozillaVersion(version)
         else:
             return AncientMozillaVersion(version)
-    except ValueError:
-        raise BadDataError("Version number %s is invalid." % version)
+    except ValueError as e:
+        raise BadDataError(e)
 
 
 def get_version_parts(version):
@@ -281,7 +291,7 @@ def decrement_version(version):
 
 def get_version_class(product):
     if product in ("FirefoxVPN", "Guardian"):
-        return LooseVersion
+        return FirefoxVPNVersion
 
     return MozillaVersion
 

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -44,21 +44,21 @@ def guardian_db():
     dbo.create()
     dbo.metadata.create_all(dbo.engine)
     dbo.releases.t.insert().execute(
-        name="Guardian-Evil-1.0.0.0",
+        name="Guardian-Evil-1.0.0",
         product="Guardian",
         data_version=1,
         data=createBlob(
             """
 {
-    "name": "Guardian-Evil-1.0.0.0",
+    "name": "Guardian-Evil-1.0.0",
     "product": "Guardian",
     "schema_version": 10000,
-    "version": "1.0.0.0",
+    "version": "1.0.0",
     "required": true,
     "hashFunction": "sha512",
     "platforms": {
         "Darwin_x86_64": {
-            "fileUrl": "https://evil.com/1.0.0.0.dmg",
+            "fileUrl": "https://evil.com/1.0.0.dmg",
             "hashValue": "ghijkl"
         }
     }
@@ -69,7 +69,7 @@ def guardian_db():
     dbo.rules.t.insert().execute(
         priority=150,
         backgroundRate=100,
-        mapping="Guardian-Evil-1.0.0.0",
+        mapping="Guardian-Evil-1.0.0",
         update_type="minor",
         product="Guardian",
         channel="release",
@@ -80,32 +80,32 @@ def guardian_db():
     dbo.rules.t.insert().execute(
         priority=150,
         backgroundRate=100,
-        mapping="Guardian-Evil-1.0.0.0",
+        mapping="Guardian-Evil-1.0.0",
         update_type="minor",
         product="Guardian",
         channel="evilrelease",
         data_version=1,
     )
     dbo.releases.t.insert().execute(
-        name="Guardian-0.5.0.0",
+        name="Guardian-0.5.0",
         product="Guardian",
         data_version=1,
         data=createBlob(
             """
 {
-    "name": "Guardian-0.5.0.0",
+    "name": "Guardian-0.5.0",
     "product": "Guardian",
     "schema_version": 10000,
-    "version": "0.5.0.0",
+    "version": "0.5.0",
     "required": true,
     "hashFunction": "sha512",
     "platforms": {
         "WINNT_x86_64": {
-            "fileUrl": "https://good.com/0.5.0.0.msi",
+            "fileUrl": "https://good.com/0.5.0.msi",
             "hashValue": "abcdef"
         },
         "Darwin_x86_64": {
-            "fileUrl": "https://good.com/0.5.0.0.dmg",
+            "fileUrl": "https://good.com/0.5.0.dmg",
             "hashValue": "ghijkl"
         }
     }
@@ -114,25 +114,25 @@ def guardian_db():
         ),
     )
     dbo.releases.t.insert().execute(
-        name="Guardian-0.6.0.0",
+        name="Guardian-0.6.0",
         product="Guardian",
         data_version=1,
         data=createBlob(
             """
 {
-    "name": "Guardian-0.6.0.0",
+    "name": "Guardian-0.6.0",
     "product": "Guardian",
     "schema_version": 10000,
-    "version": "0.6.0.0",
+    "version": "0.6.0",
     "required": true,
     "hashFunction": "sha512",
     "platforms": {
         "WINNT_x86_64": {
-            "fileUrl": "https://good.com/0.6.0.0.msi",
+            "fileUrl": "https://good.com/0.6.0.msi",
             "hashValue": "abcpqr"
         },
         "Darwin_x86_64": {
-            "fileUrl": "https://good.com/0.6.0.0.dmg",
+            "fileUrl": "https://good.com/0.6.0.dmg",
             "hashValue": "ghivwx"
         }
     }
@@ -141,25 +141,25 @@ def guardian_db():
         ),
     )
     dbo.releases.t.insert().execute(
-        name="Guardian-1.0.0.0",
+        name="Guardian-1.0.0",
         product="Guardian",
         data_version=1,
         data=createBlob(
             """
 {
-    "name": "Guardian-1.0.0.0",
+    "name": "Guardian-1.0.0",
     "product": "Guardian",
     "schema_version": 10000,
-    "version": "1.0.0.0",
+    "version": "1.0.0",
     "required": true,
     "hashFunction": "sha512",
     "platforms": {
         "WINNT_x86_64": {
-            "fileUrl": "https://good.com/1.0.0.0.msi",
+            "fileUrl": "https://good.com/1.0.0.msi",
             "hashValue": "mnopqr"
         },
         "Darwin_x86_64": {
-            "fileUrl": "https://good.com/1.0.0.0.dmg",
+            "fileUrl": "https://good.com/1.0.0.dmg",
             "hashValue": "stuvwx"
         }
     }
@@ -170,17 +170,17 @@ def guardian_db():
     dbo.rules.t.insert().execute(
         priority=120,
         backgroundRate=100,
-        mapping="Guardian-0.5.0.0",
+        mapping="Guardian-0.5.0",
         update_type="minor",
         product="Guardian",
         channel="release",
-        version="<0.5.0.0",
+        version="<0.5.0",
         data_version=1,
     )
     dbo.rules.t.insert().execute(
         priority=110,
         backgroundRate=100,
-        mapping="Guardian-0.6.0.0",
+        mapping="Guardian-0.6.0",
         update_type="minor",
         product="Guardian",
         osVersion="obsolete",
@@ -191,7 +191,7 @@ def guardian_db():
     dbo.rules.t.insert().execute(
         priority=100,
         backgroundRate=100,
-        mapping="Guardian-1.0.0.0",
+        mapping="Guardian-1.0.0",
         update_type="minor",
         product="Guardian",
         channel="release",
@@ -200,8 +200,8 @@ def guardian_db():
     dbo.rules.t.insert().execute(
         priority=100,
         backgroundRate=0,
-        mapping="Guardian-1.0.0.0",
-        fallbackMapping="Guardian-0.5.0.0",
+        mapping="Guardian-1.0.0",
+        fallbackMapping="Guardian-0.5.0",
         update_type="minor",
         product="Guardian",
         channel="release-rollout",
@@ -211,7 +211,7 @@ def guardian_db():
     dbo.rules.t.insert().execute(
         priority=100,
         backgroundRate=100,
-        mapping="Guardian-1.0.0.0",
+        mapping="Guardian-1.0.0",
         update_type="minor",
         product="Guardian",
         channel="alpha",
@@ -280,32 +280,32 @@ def client(app):
     "version,buildTarget,channel,code,response",
     [
         (
-            "0.4.0.0",
+            "0.4.0",
             "WINNT_x86_64",
             "release",
             200,
-            {"required": True, "url": "https://good.com/0.5.0.0.msi", "version": "0.5.0.0", "hashFunction": "sha512", "hashValue": "abcdef"},
+            {"required": True, "url": "https://good.com/0.5.0.msi", "version": "0.5.0", "hashFunction": "sha512", "hashValue": "abcdef"},
         ),
         (
-            "0.6.0.0",
+            "0.6.0",
             "WINNT_x86_64",
             "release",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
         (
-            "0.99.99.99",
+            "0.99.99",
             "WINNT_x86_64",
             "release",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
-        ("1.0.0.0", "WINNT_x86_64", "release", 404, {}),
-        ("0.6.0.0", "Linux_x86_64", "release", 404, {}),
-        ("0.6.0.0", "WINNT_x86_64", "beta", 404, {}),
+        ("1.0.0", "WINNT_x86_64", "release", 404, {}),
+        ("0.6.0", "Linux_x86_64", "release", 404, {}),
+        ("0.6.0", "WINNT_x86_64", "beta", 404, {}),
         # This shouldn't match because the rule on the alpha channel contains fields not used by this type of update query.
-        ("0.6.0.0", "WINNT_x86_64", "alpha", 404, {}),
-        ("0.6.0.0", "Darwin_x86_64", "evilrelease", 200, {}),
+        ("0.6.0", "WINNT_x86_64", "alpha", 404, {}),
+        ("0.6.0", "Darwin_x86_64", "evilrelease", 200, {}),
     ],
 )
 def testGuardianResponseV1(client, version, buildTarget, channel, code, response):
@@ -327,25 +327,25 @@ def testGuardianResponseV1(client, version, buildTarget, channel, code, response
     "version,buildTarget,channel,code,response",
     [
         (
-            "0.4.0.0",
+            "0.4.0",
             "WINNT_x86_64",
             "release",
             200,
-            {"required": True, "url": "https://good.com/0.5.0.0.msi", "version": "0.5.0.0", "hashFunction": "sha512", "hashValue": "abcdef"},
+            {"required": True, "url": "https://good.com/0.5.0.msi", "version": "0.5.0", "hashFunction": "sha512", "hashValue": "abcdef"},
         ),
         (
-            "0.6.0.0",
+            "0.6.0",
             "WINNT_x86_64",
             "release",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
         (
-            "0.99.99.99",
+            "0.99.99",
             "WINNT_x86_64",
             "release",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
     ],
 )
@@ -362,19 +362,19 @@ def testGuardianResponseV1WithoutSigning(client, version, buildTarget, channel, 
 @pytest.mark.parametrize(
     "forceValue,response",
     [
-        (FORCE_MAIN_MAPPING, {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"}),
+        (FORCE_MAIN_MAPPING, {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"}),
         (
             FORCE_FALLBACK_MAPPING,
-            {"required": True, "url": "https://good.com/0.5.0.0.msi", "version": "0.5.0.0", "hashFunction": "sha512", "hashValue": "abcdef"},
+            {"required": True, "url": "https://good.com/0.5.0.msi", "version": "0.5.0", "hashFunction": "sha512", "hashValue": "abcdef"},
         ),
-        (None, {"required": True, "url": "https://good.com/0.5.0.0.msi", "version": "0.5.0.0", "hashFunction": "sha512", "hashValue": "abcdef"}),
+        (None, {"required": True, "url": "https://good.com/0.5.0.msi", "version": "0.5.0", "hashFunction": "sha512", "hashValue": "abcdef"}),
     ],
 )
 def testGuardianResponseV1WithGradualRollout(client, forceValue, response):
     qs = {}
     if forceValue:
         qs["force"] = forceValue.query_value
-    ret = client.get("/json/1/Guardian/0.4.0.0/WINNT_x86_64/release-rollout/update.json", query_string=qs)
+    ret = client.get("/json/1/Guardian/0.4.0/WINNT_x86_64/release-rollout/update.json", query_string=qs)
     assert ret.status_code == 200
     assert ret.mimetype == "application/json"
     assert ret.get_json() == response
@@ -387,51 +387,51 @@ def testGuardianResponseV1WithGradualRollout(client, forceValue, response):
     "version,buildTarget,channel,osVersion,code,response",
     [
         (
-            "0.4.0.0",
+            "0.4.0",
             "WINNT_x86_64",
             "release",
             "Windows 10",
             200,
-            {"required": True, "url": "https://good.com/0.5.0.0.msi", "version": "0.5.0.0", "hashFunction": "sha512", "hashValue": "abcdef"},
+            {"required": True, "url": "https://good.com/0.5.0.msi", "version": "0.5.0", "hashFunction": "sha512", "hashValue": "abcdef"},
         ),
         (
-            "0.5.0.0",
+            "0.5.0",
             "WINNT_x86_64",
             "release",
             "current",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
         (
-            "0.5.0.0",
+            "0.5.0",
             "WINNT_x86_64",
             "release",
             "obsolete",
             200,
-            {"required": True, "url": "https://good.com/0.6.0.0.msi", "version": "0.6.0.0", "hashFunction": "sha512", "hashValue": "abcpqr"},
+            {"required": True, "url": "https://good.com/0.6.0.msi", "version": "0.6.0", "hashFunction": "sha512", "hashValue": "abcpqr"},
         ),
         (
-            "0.6.0.0",
+            "0.6.0",
             "WINNT_x86_64",
             "release",
             "Windows 10",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
         (
-            "0.99.99.99",
+            "0.99.99",
             "WINNT_x86_64",
             "release",
             "Windows 10",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
-        ("1.0.0.0", "WINNT_x86_64", "release", "Windows 10", 404, {}),
-        ("0.6.0.0", "Linux_x86_64", "release", "Linux", 404, {}),
-        ("0.6.0.0", "WINNT_x86_64", "beta", "Windows 10", 404, {}),
+        ("1.0.0", "WINNT_x86_64", "release", "Windows 10", 404, {}),
+        ("0.6.0", "Linux_x86_64", "release", "Linux", 404, {}),
+        ("0.6.0", "WINNT_x86_64", "beta", "Windows 10", 404, {}),
         # This shouldn't match because the rule on the alpha channel contains fields not used by this type of update query.
-        ("0.6.0.0", "WINNT_x86_64", "alpha", "Windows 10", 404, {}),
-        ("0.6.0.0", "Darwin_x86_64", "evilrelease", "Darwin 13", 200, {}),
+        ("0.6.0", "WINNT_x86_64", "alpha", "Windows 10", 404, {}),
+        ("0.6.0", "Darwin_x86_64", "evilrelease", "Darwin 13", 200, {}),
     ],
 )
 def testGuardianResponseV2(client, version, buildTarget, channel, osVersion, code, response):
@@ -451,28 +451,28 @@ def testGuardianResponseV2(client, version, buildTarget, channel, osVersion, cod
     "version,buildTarget,channel,osVersion,code,response",
     [
         (
-            "0.4.0.0",
+            "0.4.0",
             "WINNT_x86_64",
             "release",
             "Windows 10",
             200,
-            {"required": True, "url": "https://good.com/0.5.0.0.msi", "version": "0.5.0.0", "hashFunction": "sha512", "hashValue": "abcdef"},
+            {"required": True, "url": "https://good.com/0.5.0.msi", "version": "0.5.0", "hashFunction": "sha512", "hashValue": "abcdef"},
         ),
         (
-            "0.6.0.0",
+            "0.6.0",
             "WINNT_x86_64",
             "release",
             "Windows 10",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
         (
-            "0.99.99.99",
+            "0.99.99",
             "WINNT_x86_64",
             "release",
             "Windows 10",
             200,
-            {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
+            {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"},
         ),
     ],
 )
@@ -489,19 +489,19 @@ def testGuardianResponseV2WithoutSigning(client, version, buildTarget, channel, 
 @pytest.mark.parametrize(
     "forceValue,response",
     [
-        (FORCE_MAIN_MAPPING, {"required": True, "url": "https://good.com/1.0.0.0.msi", "version": "1.0.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"}),
+        (FORCE_MAIN_MAPPING, {"required": True, "url": "https://good.com/1.0.0.msi", "version": "1.0.0", "hashFunction": "sha512", "hashValue": "mnopqr"}),
         (
             FORCE_FALLBACK_MAPPING,
-            {"required": True, "url": "https://good.com/0.5.0.0.msi", "version": "0.5.0.0", "hashFunction": "sha512", "hashValue": "abcdef"},
+            {"required": True, "url": "https://good.com/0.5.0.msi", "version": "0.5.0", "hashFunction": "sha512", "hashValue": "abcdef"},
         ),
-        (None, {"required": True, "url": "https://good.com/0.5.0.0.msi", "version": "0.5.0.0", "hashFunction": "sha512", "hashValue": "abcdef"}),
+        (None, {"required": True, "url": "https://good.com/0.5.0.msi", "version": "0.5.0", "hashFunction": "sha512", "hashValue": "abcdef"}),
     ],
 )
 def testGuardianResponseV2WithGradualRollout(client, forceValue, response):
     qs = {}
     if forceValue:
         qs["force"] = forceValue.query_value
-    ret = client.get("/json/2/Guardian/0.4.0.0/WINNT_x86_64/release-rollout/Windows%2010/update.json", query_string=qs)
+    ret = client.get("/json/2/Guardian/0.4.0/WINNT_x86_64/release-rollout/Windows%2010/update.json", query_string=qs)
     assert ret.status_code == 200
     assert ret.mimetype == "application/json"
     assert ret.get_json() == response
@@ -511,7 +511,7 @@ def testGuardianResponseV2WithGradualRollout(client, forceValue, response):
 
 @pytest.mark.usefixtures("guardian_db")
 def testXMLForGuardianBlob(client):
-    ret = client.get("/update/1/Guardian/0.4.0.0/default/WINNT_x86_64/en-US/release/update.xml")
+    ret = client.get("/update/1/Guardian/0.4.0/default/WINNT_x86_64/en-US/release/update.xml")
     assert ret.status_code == 400
 
 
@@ -521,3 +521,10 @@ def testJSONForAppReleaseBlob(client):
     assert ret.status_code < 500
     ret = client.get("/json/2/b/127.0/p/release/default/update.json")
     assert ret.status_code < 500
+
+
+@pytest.mark.usefixtures("guardian_db")
+def testJSONBadAppVersion(client):
+    ret = client.get("/update/1/Guardian/0_4/default/WINNT_x86_64/en-US/release/update.xml")
+    assert ret.status_code == 400
+    assert ret.text == "Invalid app version 0_4"


### PR DESCRIPTION
As far as I can tell, version numbers only contain digits and periods, so we can do without LooseVersion here, reject bad version strings, and ensure comparisons work.

Fixes #3441