### PR TITLE
Run tox with `uv run --locked`

### DIFF
--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -21,7 +21,7 @@ task-defaults:
             using: run-task
             checkout:
                 balrog: {}
-            command: ['uv', 'run', 'tox']
+            command: ['uv', 'run', '--locked', 'tox']
 
 tasks:
     backend:


### PR DESCRIPTION
We're using the locked tox runner but calling tox via uv without `--locked` was making it completely useless since the outer command was updating the lockfile before it even reached tox. Use `--locked` on that one too.