### PR TITLE
Run uv with `--locked` for backend tests too

### DIFF
--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -28,7 +28,7 @@ tasks:
         description: balrog backend tests
         run:
             cwd: '{checkout}'
-            command: 'taskcluster/scripts/get-coveralls-token uv run tox'
+            command: 'taskcluster/scripts/get-coveralls-token uv run --locked tox'
         worker:
             env:
                 TOXENV: 'py313,coveralls'


### PR DESCRIPTION
beaaa22a9ad30c711d09caf208f245d73f961a6b added the --frozen flag to other tests but I missed that the backend tests also call uv in a different way (because of coveralls).