### PR TITLE
Bug 1934516 / bug 1934514 - reject sc_id in POST body when creating scheduled changes

### DIFF
--- a/src/auslib/web/admin/emergency_shutoff.py
+++ b/src/auslib/web/admin/emergency_shutoff.py
@@ -62,6 +62,8 @@ def schedule_deletion(sc_emergency_shutoff, changed_by, transaction):
     if change_type != "delete":
         return problem(400, "Bad Request", "Invalid or missing change_type")
 
+    if "sc_id" in sc_emergency_shutoff:
+        return problem(400, "Bad Request", "sc_id cannot be set when scheduling a new change")
     return post_scheduled_changes(
         sc_table=dbo.emergencyShutoffs.scheduled_changes, what=sc_emergency_shutoff, transaction=transaction, changed_by=changed_by, change_type=change_type
     )

--- a/src/auslib/web/admin/views/permissions.py
+++ b/src/auslib/web/admin/views/permissions.py
@@ -145,6 +145,8 @@ def schedule_change(sc_permission_body, transaction, changed_by):
     change_type = sc_permission_body.get("change_type")
 
     what = sc_permission_body
+    if "sc_id" in what:
+        return problem(400, "Bad Request", "sc_id cannot be set when scheduling a new change")
     print(what, flush=True)
     if what.get("options", None):
         what["options"] = json.loads(what.get("options"))

--- a/src/auslib/web/admin/views/releases.py
+++ b/src/auslib/web/admin/views/releases.py
@@ -417,6 +417,8 @@ def get_scheduled_changes():
 @transactionHandler
 def create_scheduled_change(sc_release_body, transaction, changed_by):
     what = sc_release_body
+    if "sc_id" in what:
+        return problem(400, "Bad Request", "sc_id cannot be set when scheduling a new change")
     if what.get("when", None) is None:
         return problem(400, "Bad Request", "'when' cannot be set to null when scheduling a new change " "for a Release")
     change_type = what.get("change_type")

--- a/src/auslib/web/admin/views/required_signoffs.py
+++ b/src/auslib/web/admin/views/required_signoffs.py
@@ -151,6 +151,8 @@ def product_get_scheduled_changes():
 def product_create_scheduled_change(sc_rs_product_body, transaction, changed_by):
     if sc_rs_product_body.get("when", None) is None:
         return problem(400, "Bad Request", "when cannot be set to null when scheduling a new change " "for a Product Required Signoff")
+    if "sc_id" in sc_rs_product_body:
+        return problem(400, "Bad Request", "sc_id cannot be set when scheduling a new change")
     change_type = sc_rs_product_body.get("change_type")
 
     what = {}
@@ -309,6 +311,8 @@ def permissions_get_scheduled_changes():
 def permissions_create_scheduled_change(sc_rs_permission_body, transaction, changed_by):
     if sc_rs_permission_body.get("when", None) is None:
         return problem(400, "Bad Request", "'when' cannot be set to null when scheduling a new change " "for a Permissions Required Signoff")
+    if "sc_id" in sc_rs_permission_body:
+        return problem(400, "Bad Request", "sc_id cannot be set when scheduling a new change")
     change_type = sc_rs_permission_body.get("change_type")
 
     what = {}

--- a/src/auslib/web/admin/views/rules.py
+++ b/src/auslib/web/admin/views/rules.py
@@ -191,6 +191,8 @@ def get_scheduled_changes():
 def create_scheduled_change(sc_rule_body, transaction, changed_by):
     if sc_rule_body.get("when", None) is None:
         return problem(400, "Bad Request", "'when' cannot be set to null when scheduling a new change " "for a Rule")
+    if "sc_id" in sc_rule_body:
+        return problem(400, "Bad Request", "sc_id cannot be set when scheduling a new change")
     if sc_rule_body:
         change_type = sc_rule_body.get("change_type")
     else:

--- a/tests/admin/views/test_emergency_shutoff.py
+++ b/tests/admin/views/test_emergency_shutoff.py
@@ -127,6 +127,12 @@ class TestEmergencyShutoff(ViewTest):
         self.assertTrue(sc)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def test_schedule_deletion_rejects_sc_id(self):
+        data = {"when": 4200024, "change_type": "delete", "data_version": 1, "product": "Fennec", "channel": "beta", "sc_id": 9999}
+        ret = self._post("/scheduled_changes/emergency_shutoff", data=data)
+        self.assertEqual(ret.status_code, 400)
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
     def test_update_scheduled_deletion(self):
         data = {"when": 123454321, "sc_data_version": 1}
         ret = self._post("/scheduled_changes/emergency_shutoff/1", data=data)

--- a/tests/admin/views/test_permissions.py
+++ b/tests/admin/views/test_permissions.py
@@ -747,6 +747,12 @@ class TestPermissionsScheduledChanges(ViewTest):
         self.assertEqual(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeRejectsScId(self):
+        data = {"when": 400000000, "permission": "release", "username": "jill", "change_type": "insert", "sc_id": 9999}
+        ret = self._post("/scheduled_changes/permissions", data=data)
+        self.assertEqual(ret.status_code, 400, ret.get_data())
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testAddScheduledChangeNewPermissionEmptyDictOptions(self):
         data = {"when": 400000000, "permission": "release", "username": "jill", "options": "{}", "change_type": "insert"}
         ret = self._post("/scheduled_changes/permissions", data=data)

--- a/tests/admin/views/test_releases.py
+++ b/tests/admin/views/test_releases.py
@@ -1677,6 +1677,19 @@ class TestReleasesScheduledChanges(ViewTest):
         self.assertDictEqual(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeRejectsScId(self):
+        data = {
+            "when": 5200000000,
+            "name": "q",
+            "data": '{"name": "q", "hashFunction": "sha512", "schema_version": 1}',
+            "product": "q",
+            "change_type": "insert",
+            "sc_id": 9999,
+        }
+        ret = self._post("/scheduled_changes/releases", data=data)
+        self.assertEqual(ret.status_code, 400, ret.get_data())
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testAddScheduledChangeUpdateToReadWrite(self):
         data = {"change_type": "update", "name": "z", "when": 4200024, "read_only": False, "data_version": 1}
         resp = self._post("/scheduled_changes/releases", data=data)

--- a/tests/admin/views/test_required_signoffs.py
+++ b/tests/admin/views/test_required_signoffs.py
@@ -568,6 +568,12 @@ class TestProductRequiredSignoffsScheduledChanges(ViewTest):
         self.assertEqual(dict(cond[0]), cond_expected)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeRejectsScId(self):
+        data = {"when": 400000000, "product": "fake", "channel": "k", "role": "releng", "signoffs_required": 1, "change_type": "insert", "sc_id": 9999}
+        ret = self._post("/scheduled_changes/required_signoffs/product", data=data)
+        self.assertEqual(ret.status_code, 400, ret.get_data())
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testUpdateScheduledUnknownScheduledChangeID(self):
         data = {"signoffs_required": 1, "data_version": 1, "sc_data_version": 1, "when": 200000000}
         ret = self._post("/scheduled_changes/required_signoffs/product/98765432", data=data)
@@ -1273,6 +1279,12 @@ class TestPermissionsRequiredSignoffsScheduledChanges(ViewTest):
         self.assertEqual(len(cond), 1)
         cond_expected = {"sc_id": 5, "data_version": 1, "when": 400000000}
         self.assertEqual(dict(cond[0]), cond_expected)
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeRejectsScId(self):
+        data = {"when": 400000000, "product": "foo", "role": "relman", "signoffs_required": 1, "change_type": "insert", "sc_id": 9999}
+        ret = self._post("/scheduled_changes/required_signoffs/permissions", data=data)
+        self.assertEqual(ret.status_code, 400, ret.get_data())
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testUpdateScheduledChangeExistingRequiredSignoff(self):

--- a/tests/admin/views/test_rules.py
+++ b/tests/admin/views/test_rules.py
@@ -2281,6 +2281,22 @@ class TestRuleScheduledChanges(ViewTest):
         self.assertEqual(ret.status_code, 400)
 
     @mock.patch("time.time", mock.MagicMock(return_value=300))
+    def testAddScheduledChangeRejectsScId(self):
+        data = {
+            "when": 1234567,
+            "priority": 120,
+            "backgroundRate": 100,
+            "product": "blah",
+            "channel": "blah",
+            "update_type": "minor",
+            "mapping": "a",
+            "change_type": "insert",
+            "sc_id": 9999,
+        }
+        ret = self._post("/scheduled_changes/rules", data=data)
+        self.assertEqual(ret.status_code, 400, ret.get_data())
+
+    @mock.patch("time.time", mock.MagicMock(return_value=300))
     def testUpdateCompletedScheduleChange(self):
         data = {
             "when": 2000000,


### PR DESCRIPTION
A few things going on here:
- all scheduled change creation endpoints (POST /api/scheduled_changes/*) accept a JSON request body and pass its fields through to a database INSERT
- because our schemas use `allOf` and `$ref` we can't use `additionalProperties: false`
- connexion uses json schema draft 4, so we can't use draft 2019-09 keyword `unevaluatedProperties` either
- because sc_id is the AUTO_INCREMENT primary key of the scheduled changes table, MySQL treats an explicit insert of that column as authoritative and advances the auto-increment counter to `max(current_value, inserted_value) + 1`. An authenticated attacker can therefore send a single request with `"sc_id": 2147483647` (`INT32_MAX`), causing the counter to overflow on the next legitimate insert and permanently breaking scheduled change creation for that table.

Fix this by checking for that parameter before inserting a scheduled change and rejecting the request.