### PR TITLE
Bug 1934514 - Assert autoincrement primary keys are not set explicitly on insert

### DIFF
--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -1092,7 +1092,7 @@ class ConditionsTable(AUSTable):
 
         self.enabled_condition_groups = {k: v for k, v in self.condition_groups.items() if k in conditions}
 
-        self.table = Table("{}_conditions".format(baseName), metadata, Column("sc_id", Integer, primary_key=True))
+        self.table = Table("{}_conditions".format(baseName), metadata, Column("sc_id", Integer, primary_key=True, autoincrement=False))
 
         if "uptake" in conditions:
             self.table.append_column(Column("telemetry_product", String(15)))

--- a/src/auslib/db.py
+++ b/src/auslib/db.py
@@ -387,6 +387,9 @@ class AUSTable(object):
 
         :rtype: sqlalchemy.sql.express.Insert
         """
+        for col in self.table.c:
+            if col.primary_key and col.autoincrement and isinstance(col.type, Integer) and col.name in columns:
+                raise ValueError("Cannot set autoincrement primary key '%s' on insert" % col.name)
         table_columns = {k: columns[k] for k in columns.keys() if k in self.table.c}
         unconsumed_columns = {k: columns[k] for k in columns.keys() if k not in table_columns}
         return self.t.insert(values=table_columns), unconsumed_columns

--- a/src/auslib/migrate/versions/037_conditions_sc_id_no_autoincrement.py
+++ b/src/auslib/migrate/versions/037_conditions_sc_id_no_autoincrement.py
@@ -1,0 +1,30 @@
+"""Remove AUTO_INCREMENT from sc_id on all conditions tables.
+
+sc_id on conditions tables is a foreign key to the corresponding
+scheduled_changes table and is always set explicitly on insert.
+It was never intended to be AUTO_INCREMENT.
+"""
+
+CONDITIONS_TABLES = [
+    "emergency_shutoffs_scheduled_changes_conditions",
+    "permissions_req_signoffs_scheduled_changes_conditions",
+    "permissions_scheduled_changes_conditions",
+    "pinnable_releases_scheduled_changes_conditions",
+    "product_req_signoffs_scheduled_changes_conditions",
+    "release_assets_scheduled_changes_conditions",
+    "releases_json_scheduled_changes_conditions",
+    "releases_scheduled_changes_conditions",
+    "rules_scheduled_changes_conditions",
+]
+
+
+def upgrade(migrate_engine):
+    if migrate_engine.name == "mysql":
+        for table in CONDITIONS_TABLES:
+            migrate_engine.execute("ALTER TABLE %s MODIFY sc_id INTEGER NOT NULL" % table)
+
+
+def downgrade(migrate_engine):
+    if migrate_engine.name == "mysql":
+        for table in CONDITIONS_TABLES:
+            migrate_engine.execute("ALTER TABLE %s MODIFY sc_id INTEGER NOT NULL AUTO_INCREMENT" % table)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -206,7 +206,7 @@ class TestTableMixin(object):
 
         class TestTable(AUSTable):
             def __init__(self, db, metadata):
-                self.table = Table("test", metadata, Column("id", Integer, primary_key=True, autoincrement=True), Column("foo", Integer))
+                self.table = Table("test", metadata, Column("id", Integer, primary_key=True, autoincrement=False), Column("foo", Integer))
                 AUSTable.__init__(self, db, "sqlite", historyClass=HistoryTable)
 
         class TestAutoincrementTable(AUSTable):
@@ -434,12 +434,8 @@ class TestHistoryTable(unittest.TestCase, TestTableMixin, MemoryDatabaseMixin):
         self.assertEqual(ret, [(24, "george", 999, 5, None, None), (25, "george", 1000, 5, 0, 1)])
 
     @mock.patch("time.time", mock.MagicMock(return_value=1.0))
-    def testHistoryUponAutoincrementInsert(self):
-        self.test.insert(changed_by="george", foo=0)
-        # This actual generates history for a row we already have history for
-        # because sqlite just uses max(id)+1 as the next available primary key.
-        # Even if we insert and delete id 4 from the database, we still
-        # get id=4 for the next autoincrement insert.
+    def testHistoryUponInsertWithExistingHistory(self):
+        self.test.insert(changed_by="george", id=4, foo=0)
         ret = self.test.history.t.select().where(self.test.history.id == 4).execute().fetchall()[-2:]
         self.assertEqual(ret, [(24, "george", 999, 4, None, None), (25, "george", 1000, 4, 0, 1)])
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6092,6 +6092,8 @@ class TestDBModel(unittest.TestCase, NamedFileDatabaseMixin):
             pass
 
         versions_migrate_tests_dict = {
+            # MySQL-only migration (removes AUTO_INCREMENT from conditions table sc_id), no-op on SQLite
+            36: _noop,
             35: self._add_emergency_shutoff_comments,
             34: self._add_pinnable_releases_tables,
             33: self._add_release_json_tables,


### PR DESCRIPTION
Followup to #3754 to catch any such issues at the db layer even if they make it through the web layer.