### PR TITLE
Remove hypothesis pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,7 @@ dev = [
     "fakeredis",
     "flake8",
     "flake8-black",
-    # https://github.com/HypothesisWorks/hypothesis/issues/4638
-    "hypothesis<6.150.0",
+    "hypothesis",
     "isort",
     "mock",
     "pytest",

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ dev = [
     { name = "fakeredis" },
     { name = "flake8" },
     { name = "flake8-black" },
-    { name = "hypothesis", specifier = "<6.150.0" },
+    { name = "hypothesis" },
     { name = "isort" },
     { name = "mock" },
     { name = "pytest" },


### PR DESCRIPTION
The incompatibility was fixed in
https://github.com/HypothesisWorks/hypothesis/pull/4639

We should still fix the code on our side but don't have to block updates to hypothesis in the mean time.