### PR TITLE
tests: consolidate pytest config in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     "hypothesis<6.150.0",
     "isort",
     "mock",
-    "pytest",
+    "pytest>=9",
     "pytest-asyncio",
     "pytest-cov",
     "pytest-responses",
@@ -110,6 +110,15 @@ force_grid_wrap = 0
 use_parentheses = true
 line_length = 160
 
-[tool.pytest.ini_options]
-asyncio_mode="auto"
-asyncio_default_fixture_loop_scope="function"
+[tool.pytest]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+norecursedirs = [".tox", ".git", ".hg", "sandbox", "build"]
+python_files = ["test_*.py"]
+filterwarnings = [
+    "ignore",
+    "error:::auslib",
+    "ignore::ImportWarning:auslib.db",
+    "default::DeprecationWarning:auslib",
+    "default::PendingDeprecationWarning:auslib",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -53,16 +53,6 @@ show-source = True
 # to add it again ourselves.
 ignore = E203,W503
 
-[pytest]
-norecursedirs = .tox .git .hg sandbox build
-python_files = test_*.py
-filterwarnings =
-    ignore
-    error:::auslib
-    ignore::ImportWarning:auslib.db
-    default::DeprecationWarning:auslib
-    default::PendingDeprecationWarning:auslib
-
 
 [coverage:run]
 branch = true

--- a/uv.lock
+++ b/uv.lock
@@ -324,7 +324,7 @@ dev = [
     { name = "hypothesis", specifier = "<6.150.0" },
     { name = "isort" },
     { name = "mock" },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-responses" },


### PR DESCRIPTION
Having split config caused this warning:

> configfile: pyproject.toml (WARNING: ignoring pytest config in tox.ini!)