### PR TITLE
fix: update redirect ui for mozcloud balrog UI

### DIFF
--- a/.github/workflows/ui-deploy.yml
+++ b/.github/workflows/ui-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       AUTH0_DOMAIN: auth.mozilla.auth0.com
       AUTH0_CLIENT_ID: ${{ inputs.deploy_env == 'stage' && '43tgBNjaHHhOAPPr10zh2jodVT3t6abD' || 'Qe16eoq0Uz9eSTVDVEO15DGBPCgqoAA2' }}
       AUTH0_AUDIENCE: ${{ inputs.deploy_env == 'stage' && 'balrog-cloudops-stage' || 'balrog-production' }}
-      AUTH0_REDIRECT_URI: ${{ inputs.deploy_env == 'stage' && 'https://balrog.allizom.org/login' || 'https://balrog.services.mozilla.com/login' }}
+      AUTH0_REDIRECT_URI: ${{ inputs.deploy_env == 'stage' && 'https://balrog.allizom.org/login' || 'https://balrog.mozilla.org/login' }}
       GCS_NIGHTLY_HISTORY_BUCKET: ${{ inputs.deploy_env == 'stage' && 'https://www.googleapis.com/storage/v1/b/balrog-stage-nightly-history-v2/o' || 'https://www.googleapis.com/storage/v1/b/balrog-prod-nightly-history-v2/o' }}
       GCS_RELEASES_HISTORY_BUCKET: ${{ inputs.deploy_env == 'stage' && 'https://www.googleapis.com/storage/v1/b/balrog-stage-release-history-v2/o' || 'https://www.googleapis.com/storage/v1/b/balrog-prod-release-history-v2/o' }}
     defaults:


### PR DESCRIPTION
In order to facilitate easier testing of the MozCloud deployment of the Balrog UI, we decided to use a new DNS entry for it; we need the redirect URI set correctly to have the auth0 login process complete correctly.