### PR TITLE
chore: move dbdump fetch script to mozcloud bucket

### DIFF
--- a/scripts/get-prod-db-dump.py
+++ b/scripts/get-prod-db-dump.py
@@ -11,7 +11,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 HOST = "https://storage.googleapis.com"
-PATH = "/balrog-prod-dbdump-v1/dump.sql.txt.xz"
+PATH = "/balrog-prod-dbdump-v2/dump.sql.txt.xz"
 LOCAL_DB_PATH = os.getenv("LOCAL_DUMP", "/app/scripts/prod_db_dump.sql.xz")
 TIMEOUT = 10
 


### PR DESCRIPTION
To be merged after we cut over to MozCloud prod.

MozCloud bucket is define over here: https://github.com/mozilla/webservices-infra/blob/01b6509cb55f30b0fc4e226a0798d0d552aa4d80/balrog/k8s/balrog-admin/values-prod.yaml#L48