### PR TITLE
feat: allow admin to run in read-only mode

### DIFF
--- a/src/auslib/web/admin/base.py
+++ b/src/auslib/web/admin/base.py
@@ -46,13 +46,16 @@ def should_time_request():
     return True
 
 
-def create_app():
+def create_app(allow_read_only=False):
     connexion_app = connexion.App(__name__, debug=False, options={"swagger_ui": False})
     connexion_app.add_api(spec, validator_map=validator_map, strict_validation=True)
     connexion_app.add_api(path.join(current_dir, "swagger", "api_v2.yml"), base_path="/v2", strict_validation=True, validate_responses=True)
     flask_app = connexion_app.app
 
-    create_dockerflow_endpoints(flask_app)
+    if allow_read_only:
+        create_dockerflow_endpoints(flask_app, heartbeat_database_fn=lambda dbo: dbo.rules.count())
+    else:
+        create_dockerflow_endpoints(flask_app)
 
     @flask_app.before_request
     def setup_statsd():

--- a/uwsgi/admin.wsgi
+++ b/uwsgi/admin.wsgi
@@ -71,10 +71,14 @@ log = logging.getLogger(__file__)
 # statsd environment also needs to be set up before importing the application
 statsd.defaults.PREFIX = "balrog.admin"
 
+# temporarily allow admin to run in read-only mode, until MozCloud migration
+# is completed
+allow_read_only = bool(os.environ.get("BALROG_ALLOW_READ_ONLY"))
+
 from auslib.global_state import cache, dbo  # noqa
 from auslib.web.admin.base import create_app
 
-application = create_app().app
+application = create_app(allow_read_only).app
 
 cache.make_copies = True
 # We explicitly don't want a blob_version cache here because it will cause


### PR DESCRIPTION
From now until when we cut over prod to MozCloud we're going to run the database as a replica of the GCPv1 database. This means we can't make any writes through MozCloud infra. We need to accommodate the heartbeat function of admin, and make it operate as read-only until we cut over.

I intend to back this patch out entirely after cut-over.