### PR TITLE
ui: show wildcard channels in product/channel dropdown

### DIFF
--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -37,4 +37,28 @@ const ruleMatchesChannel = (rule, channel) => {
   return ruleChannelMatches || scChannelMatches;
 };
 
-export { ruleMatchesChannel };
+const buildProductChannelOptions = (products, channels, rules, separator) => {
+  const options = [];
+
+  products.forEach((product) => {
+    options.push(product);
+
+    channels.forEach((channel) => {
+      const normalizedChannel = channel.endsWith('*')
+        ? channel.slice(0, -1)
+        : channel;
+      const option = `${product}${separator}${normalizedChannel}`;
+      const pairExists = rules.some(
+        (rule) => rule.product === product && rule.channel === channel,
+      );
+
+      if (!options.includes(option) && pairExists) {
+        options.push(option);
+      }
+    });
+  });
+
+  return options.sort();
+};
+
+export { buildProductChannelOptions, ruleMatchesChannel };

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -378,8 +378,13 @@ function ListRules(props) {
       options.push(product);
 
       chs.forEach((channel) => {
-        if (!channel.endsWith('*') && pairExists(product, channel)) {
-          options.push(`${product}${productChannelSeparator}${channel}`);
+        const normalizedChannel = channel.endsWith('*')
+          ? channel.slice(0, -1)
+          : channel;
+        const option = `${product}${productChannelSeparator}${normalizedChannel}`;
+
+        if (!options.includes(option) && pairExists(product, channel)) {
+          options.push(option);
         }
       });
     });

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -83,7 +83,10 @@ import getDiffedProperties from '../../../utils/getDiffedProperties';
 import getFilteredRulesInfo from '../../../utils/getFilteredRulesInfo';
 import Link from '../../../utils/Link';
 import { ruleMatchesRequiredSignoff } from '../../../utils/requiredSignoffs';
-import { ruleMatchesChannel } from '../../../utils/rules';
+import {
+  buildProductChannelOptions,
+  ruleMatchesChannel,
+} from '../../../utils/rules';
 
 const ALL = 'all';
 const useStyles = makeStyles()((theme) => ({
@@ -340,10 +343,6 @@ function ListRules(props) {
 
   const isScheduledInsert = (rule) =>
     rule.scheduledChange && rule.scheduledChange.change_type === 'insert';
-  const pairExists = (product, channel) =>
-    rules.data?.data.rules.some(
-      (rule) => rule.product === product && rule.channel === channel,
-    );
   const sortRules = (rules) => {
     // Rules are sorted by priority. Rules that are
     // pending (ie: still just a Scheduled Change) will be inserted based
@@ -372,24 +371,15 @@ function ListRules(props) {
 
     const prods = products.data.data.product;
     const chs = channels.data.data.channel;
-    const options = [];
 
-    prods.forEach((product) => {
-      options.push(product);
-
-      chs.forEach((channel) => {
-        const normalizedChannel = channel.endsWith('*')
-          ? channel.slice(0, -1)
-          : channel;
-        const option = `${product}${productChannelSeparator}${normalizedChannel}`;
-
-        if (!options.includes(option) && pairExists(product, channel)) {
-          options.push(option);
-        }
-      });
-    });
-
-    setProductChannelOptions(options.sort());
+    setProductChannelOptions(
+      buildProductChannelOptions(
+        prods,
+        chs,
+        rules.data.data.rules,
+        productChannelSeparator,
+      ),
+    );
   }, [products.data, channels.data, rules.data]);
 
   useEffect(() => {

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -1,4 +1,7 @@
-import { ruleMatchesChannel } from '../src/utils/rules';
+import {
+  buildProductChannelOptions,
+  ruleMatchesChannel,
+} from '../src/utils/rules';
 
 describe('channel matching', () => {
   test('should match when only current rule matches', () => {
@@ -146,5 +149,87 @@ describe('channel matching', () => {
     );
 
     expect(result).toBeFalsy();
+  });
+});
+
+describe('buildProductChannelOptions', () => {
+  const SEP = ' : ';
+
+  test('includes product with no channel entry', () => {
+    const options = buildProductChannelOptions(['Firefox'], [], [], SEP);
+
+    expect(options).toEqual(['Firefox']);
+  });
+
+  test('includes exact channel when rule exists', () => {
+    const rules = [{ product: 'Firefox', channel: 'nightly' }];
+    const options = buildProductChannelOptions(
+      ['Firefox'],
+      ['nightly'],
+      rules,
+      SEP,
+    );
+
+    expect(options).toContain('Firefox : nightly');
+  });
+
+  test('strips * from wildcard channel', () => {
+    const rules = [{ product: 'Firefox', channel: 'nightly*' }];
+    const options = buildProductChannelOptions(
+      ['Firefox'],
+      ['nightly*'],
+      rules,
+      SEP,
+    );
+
+    expect(options).toContain('Firefox : nightly');
+    expect(options).not.toContain('Firefox : nightly*');
+  });
+
+  test('deduplicates when both nightly and nightly* rules exist', () => {
+    const rules = [
+      { product: 'Firefox', channel: 'nightly' },
+      { product: 'Firefox', channel: 'nightly*' },
+    ];
+    const options = buildProductChannelOptions(
+      ['Firefox'],
+      ['nightly', 'nightly*'],
+      rules,
+      SEP,
+    );
+
+    expect(options.filter((o) => o === 'Firefox : nightly')).toHaveLength(1);
+  });
+
+  test('does not add channel entry when no matching rule exists', () => {
+    const rules = [{ product: 'Thunderbird', channel: 'nightly' }];
+    const options = buildProductChannelOptions(
+      ['Firefox'],
+      ['nightly'],
+      rules,
+      SEP,
+    );
+
+    expect(options).not.toContain('Firefox : nightly');
+  });
+
+  test('handles multiple products and channels', () => {
+    const rules = [
+      { product: 'Firefox', channel: 'nightly*' },
+      { product: 'Firefox', channel: 'release' },
+      { product: 'Thunderbird', channel: 'beta*' },
+    ];
+    const options = buildProductChannelOptions(
+      ['Firefox', 'Thunderbird'],
+      ['nightly*', 'release', 'beta*'],
+      rules,
+      SEP,
+    );
+
+    expect(options).toContain('Firefox : nightly');
+    expect(options).toContain('Firefox : release');
+    expect(options).toContain('Thunderbird : beta');
+    expect(options).not.toContain('Thunderbird : nightly');
+    expect(options).not.toContain('Firefox : beta');
   });
 });


### PR DESCRIPTION
Rules with wildcard channels (e.g. `nightly*`) were invisible in the product/channel filter dropdown, making it appear a product (e.g. Widevine) had no channel-specific rules. Strip the trailing `*` when building dropdown options so `esr*` is shown as `Widevine : esr`.