### PR TITLE
fix(bug 2043228): allow renovate PRs to be created at any hour

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,5 @@
   "extends": [
     "github>mozilla-releng/reps:renovate-preset.json5"
   ],
-  "schedule": ["* 2 1,15 * *"]
+  "schedule": ["* * 1,15 * *"]
 }


### PR DESCRIPTION
From [the documentation](https://docs.renovatebot.com/key-concepts/scheduling/#global-schedule-vs-specific-schedule)

> Renovate can only update a dependency if both of these conditions are true:
>
> * The Renovate program is running (on your hardware, or on Mend's hardware)
> * The schedule set in the Renovate config file(s) allows Renovate to look for updates for that dependency

The documentation additionally describes that Mend controls when the Renovate program is running.

With this in mind, I believe the recent changes to restrict Renovate to only running at 2am UTC have resulted in fewer PRs being created. Now that we've made the change to restrict to one day a month, having them opened at any hour shouldn't be a big deal.