### PR TITLE
Re-enable refresh tokens in the UI

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -38,6 +38,7 @@ const App = () => {
             scope: process.env.AUTH0_SCOPE,
           }}
           leeway={30}
+          useRefreshTokens
           cacheLocation="localstorage"
           sessionCheckExpiryDays={7}
         >


### PR DESCRIPTION
I had disabled them in #3468 because there were a problem due to re-requesting MFA when the client was trying to use it. The issue got fixed recently (in https://mozilla-hub.atlassian.net/browse/IAM-1935) so we should be able to use refresh tokens now which will fix the issue we're currently seeing where balrog sessions are expiring after 15mn (the authorization token expiration time).

I left `useRefreshTokensFallback` off because AFAIU it'd try to login the "normal" way (but in a hidden iframe) if the refresh token fails, which would end up requiring MFA anyway and thus break.