### PR TITLE
feat: capture and send metrics for all types of signing errors

### DIFF
--- a/src/auslib/util/autograph.py
+++ b/src/auslib/util/autograph.py
@@ -19,14 +19,21 @@ def make_hash(content):
 def _sign_hash(autograph_uri, keyid, id_, key, hash_):
     auth = HawkAuth(id=id_, key=key)
     with requests.Session() as session:
-        body = [{"input": b64encode(hash_).decode("ascii"), "keyid": keyid}]
-        r = session.post(f"{autograph_uri}/sign/hash", json=body, auth=auth)
-        statsd.incr(f"autograph.code.{r.status_code}")
-        r.raise_for_status()
-        response = r.json()
-        if len(response) != 1:
-            raise Exception("Response is not length 1, cannot parse it")
-        return response[0]["signature"], response[0]["x5u"]
+        try:
+            body = [{"input": b64encode(hash_).decode("ascii"), "keyid": keyid}]
+            r = session.post(f"{autograph_uri}/sign/hash", json=body, auth=auth)
+            statsd.incr(f"autograph.code.{r.status_code}")
+            r.raise_for_status()
+            response = r.json()
+            if len(response) != 1:
+                raise Exception("Response is not length 1, cannot parse it")
+            return response[0]["signature"], response[0]["x5u"]
+        except requests.RequestException:
+            statsd.incr("autograph.requests_error")
+            raise
+        except Exception:
+            statsd.incr("autograph.unknown_error")
+            raise
 
 
 def sign_hash(autograph_uri, keyid, id, key, hash):

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from mock import mock
 
 import auslib.web.public.helpers
@@ -8,6 +9,7 @@ import auslib.web.public.json
 from auslib.AUS import FORCE_FALLBACK_MAPPING, FORCE_MAIN_MAPPING
 from auslib.blobs.base import createBlob
 from auslib.global_state import dbo
+from auslib.util.autograph import _sign_hash
 from auslib.web.public.base import create_app
 
 
@@ -521,3 +523,36 @@ def testJSONForAppReleaseBlob(client):
     assert ret.status_code < 500
     ret = client.get("/json/2/b/127.0/p/release/default/update.json")
     assert ret.status_code < 500
+
+
+@pytest.mark.usefixtures("guardian_db", "appconfig")
+@pytest.mark.parametrize(
+    "exception,metric",
+    (
+        pytest.param(
+            requests.ConnectionError,
+            "autograph.requests_error",
+            id="requests error",
+        ),
+        pytest.param(
+            Exception,
+            "autograph.unknown_error",
+            id="unknown error",
+        ),
+    ),
+)
+def testSignError(monkeypatch, app, client, responses, exception, metric):
+    monkeypatch.setitem(app.config, "AUTOGRAPH_URL", "https://autograph")
+    monkeypatch.setitem(app.config, "AUTOGRAPH_KEYID", "fake")
+    monkeypatch.setitem(app.config, "AUTOGRAPH_USERNAME", "fake")
+    monkeypatch.setitem(app.config, "AUTOGRAPH_PASSWORD", "fake")
+
+    responses.post("https://autograph/sign/hash", body=exception("error"))
+
+    # mocked to get rid of retries
+    with mock.patch("auslib.web.public.helpers.sign_hash", new=_sign_hash):
+        with mock.patch("auslib.web.public.base.statsd.pipeline") as mocked_pipeline:
+            with pytest.raises(exception):
+                client.get("/json/1/Guardian/0.4.0.0/WINNT_x86_64/release/update.json")
+
+            assert mocked_pipeline.mock_calls.count(mock.call().incr(metric)) == 1


### PR DESCRIPTION
Previously we were only capturing data on errors that resulted from a request to Autograph that actually returned a response. This missed connection errors, ssl errors, etc.

This change groups two new metrics, one for errors related to the request, and one for other errors (mostly as a "make sure we don't miss any unpredictable errors handler"). The former could be broken out further into more specific requests errors, but it's difficult to imagine what that would gain us. (In the cases I can imagine, simply knowing that "yep, we didn't get a response to autograph" seems like it ought to be enough.)