### PR TITLE
releases: avoid mutating a cached object

### DIFF
--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -383,7 +383,11 @@ def get_release(name, trans, include_sc=True):
         # the time we're serving old release data
         if base_row["data_version"] < base_data_version:
             base_row = get_base_row(name, trans)
-        base_blob = base_row["data"]
+        # Copy the base blob before merging assets into it below. In the public
+        # app base_row["data"] is a shared object handed back to every request.
+        # Merging assets in place would mutate the cached object, corrupting it
+        # for other callers and racing with concurrent readers.
+        base_blob = deepcopy(base_row["data"])
         data_versions["."] = base_row["data_version"]
 
     # same thing here for the assets -- if any of the full asset data versions

--- a/tests/web/api/test_releases.py
+++ b/tests/web/api/test_releases.py
@@ -1,3 +1,8 @@
+from copy import deepcopy
+
+from auslib.global_state import cache, dbo
+from auslib.services import releases
+
 from .base import CommonTestBase
 
 
@@ -72,6 +77,38 @@ class TestPublicReleasesAPI(CommonTestBase):
         self.assertIn("WINNT_x86_64-msvc", got["platforms"])
         platform = got["platforms"]["WINNT_x86_64-msvc"]
         self.assertIn("en-US", platform["locales"])
+
+    def test_get_release_does_not_mutate_cached_blob(self):
+        # The public app runs the cache with make_copies=False, so the cached
+        # base blob is a single object shared across every request (and, with
+        # UWSGI_THREADS>1, across concurrent threads). get_release assembles the
+        # full release by merging the separately-cached assets into the base, and
+        # it must NOT do that merge in place on the shared cached object.
+        # Reproduce the public-app caching setup and assert the cached row is
+        # left untouched after a merge.
+        release = "Firefox-56.0-build1"
+        cache.reset()
+        self.addCleanup(cache.reset)
+        # make_copies is global state, ensure it's turned off for this test
+        original_make_copies = cache.make_copies
+        cache.make_copies = False
+        self.addCleanup(setattr, cache, "make_copies", original_make_copies)
+        for cache_name in ("releases", "releases_data_version", "release_assets", "release_assets_data_versions"):
+            cache.make_cache(cache_name, 10, 10)
+
+        with dbo.begin() as trans:
+            base_only = deepcopy(releases.get_base_row(release, trans)["data"])
+            blob = releases.get_release(release, trans, include_sc=False)["blob"]
+
+        # Sanity check: the assembled blob carries per-locale asset data the base lacks
+        self.assertIn("en-US", blob["platforms"]["WINNT_x86_64-msvc"]["locales"])
+        self.assertNotEqual(blob, base_only)
+
+        # The cached base row must be byte-for-byte the DB base row,
+        # i.e. the asset merge did not write the locales into the shared cached object.
+        cached = cache.get("releases", release)
+        self.assertEqual(cached["data"], base_only)
+        self.assertNotIn("locales", cached["data"].get("platforms", {}).get("WINNT_x86_64-msvc", {}))
 
     def test_get_release_locale(self):
         ret = self.public_client.get("/api/v1/releases/Firefox.55.0a1/builds/p/l")


### PR DESCRIPTION
In get_release, copy the base blob before merging assets into it, to avoid modifying a shared object.
This was causing extra memory usage
(https://bugzilla.mozilla.org/show_bug.cgi?id=2014991#c6), because the releases cache ended up storing unwanted release assets.  And would cause a data race if/when we set UWSGI_THREADS to >1, with multiple request handlers modifying that object
(https://bugzilla.mozilla.org/show_bug.cgi?id=2003549#c7).