### PR TITLE
Don't rely on a token's liveness to choose whether to get a new one

### DIFF
--- a/ui/src/Main.jsx
+++ b/ui/src/Main.jsx
@@ -17,16 +17,14 @@ function ProtectedRoute({ children, requiresAuth }) {
   return <Suspense fallback={null}>{children}</Suspense>;
 }
 
-function setupAxiosInterceptors(getAccessTokenSilently, getIdTokenClaims) {
+function setupAxiosInterceptors(getAccessTokenSilently, isAuthenticated) {
   const requestInterceptor = axios.interceptors.request.use(async (config) => {
     const result = config;
 
     if (!config.url.startsWith('http')) {
       result.baseURL = BASE_URL;
 
-      const claims = await getIdTokenClaims();
-
-      if (claims) {
+      if (isAuthenticated) {
         try {
           const accessToken = await getAccessTokenSilently();
 
@@ -65,20 +63,20 @@ function setupAxiosInterceptors(getAccessTokenSilently, getIdTokenClaims) {
 }
 
 function Main() {
-  const { isLoading, getAccessTokenSilently, getIdTokenClaims } = useAuth0();
+  const { isLoading, getAccessTokenSilently, isAuthenticated } = useAuth0();
   const [isReady, setReady] = useState(false);
 
   useEffect(() => {
     const interceptors = setupAxiosInterceptors(
       getAccessTokenSilently,
-      getIdTokenClaims,
+      isAuthenticated,
     );
 
     return () => {
       axios.interceptors.request.eject(interceptors.request);
       axios.interceptors.response.eject(interceptors.response);
     };
-  }, [getAccessTokenSilently, getIdTokenClaims]);
+  }, [getAccessTokenSilently, isAuthenticated]);
 
   useEffect(() => {
     if (!isReady && !isLoading) {


### PR DESCRIPTION
In ce2e38decb79915ad50fd3a304d97d65ff83744d, I "abused" `getIdTokenClaims` as a way to detect whether someone was logged in or not to avoid calling `getAccessTokenSilently` since that would trigger a full login sequence on its own. Turns out auth0 had a `isAuthenticated` variable I could use for that the whole time.

We're making this change now because turning refresh tokens back on means that auth0 doesn't discard `auth0.user` anymore (since they have a refresh token), which leads the UI to think and show the user as logged in, but it does discard the claims from the cache once expired which makes axios think the user isn't.

And `getAccessTokenSilently` is the initiator of the refresh, which means an expired token would make `getIdTokenClaims` return `undefined`, which we considered as "not logged in", which prevents us from actually trying to refresh said token. Switching to `isAuthenticated` fixes that entirely.