### PR TITLE
Revert "Re-enable refresh tokens in the UI (#3812)"

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -38,7 +38,6 @@ const App = () => {
             scope: process.env.AUTH0_SCOPE,
           }}
           leeway={30}
-          useRefreshTokens
           cacheLocation="localstorage"
           sessionCheckExpiryDays={7}
         >


### PR DESCRIPTION
This reverts commit 5ce3d5859657b1f5530517a80ad6566784e16522.

1) We're missing some config on the auth0 side which is going to be a
   while before it's done. The /tokens route doesn't actually give us
   refresh tokens and its scopes are missing `offline_access` which
   means someone needs to go check a box in the API config
   (https://auth0.com/docs/secure/tokens/refresh-tokens/get-refresh-tokens)
2) It wouldn't work as is, we're never trying to actually use refresh
   tokens because we're gating that call on the wrong thing. See #3832

We can try relanding that next week once I got confirmation that we have the API settings fixed