### PR TITLE
fix: require signoff when modifying only a base release or only adding a new asset

### DIFF
--- a/src/auslib/services/releases.py
+++ b/src/auslib/services/releases.py
@@ -606,8 +606,16 @@ def set_release(name, blob, product, old_data_versions, when, changed_by, trans)
     current_assets = get_assets(name, trans)
     base_blob, new_assets = split_release(blob, blob["schema_version"])
 
+    # munge the data to get it in a consistent format; current_assets is a dict,
+    # but contains non-blob columns from the database
+    # new_assets is a list of tuples of (path, asset)
+    # `path` is a tuple of the keys used to reach the `asset`, eg:
+    # ("platforms", "linux", "locales", "de") corresponds to
+    # blob["platforms"]["linux"]["locales"]["de"] in a reconstructed full blob
+    current_asset_data = {path: asset["data"] for path, asset in current_assets.items()}
+    new_asset_data = {"." + ".".join(path): asset for path, asset in new_assets}
     # if current == new, we will just be cancelling a scheduled change
-    if current_base_blob != base_blob and current_assets != new_assets and not when and any([v for v in live_on_product_channels.values()]):
+    if (current_base_blob != base_blob or current_asset_data != new_asset_data) and not when and any([v for v in live_on_product_channels.values()]):
         raise SignoffRequiredError("Signoff is required, cannot update Release directly")
 
     seen_assets = set()

--- a/tests/admin/views/test_releases_v2.py
+++ b/tests/admin/views/test_releases_v2.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy, deepcopy
 
 import pytest
 from aiohttp import ClientError
@@ -580,6 +580,43 @@ def test_put_fails_when_signoff_required(api, firefox_56_0_build1):
     firefox_56_0_build1["detailsUrl"] = "https://newurl"
     firefox_56_0_build1["platforms"]["Darwin_x86_64-gcc3-u-i386-x86_64"]["locales"]["de"]["buildID"] = "9999999999999"
     old_data_versions = populate_versions_dict(firefox_56_0_build1)
+    old_data_versions["."] = 1
+
+    ret = api.put("/v2/releases/Firefox-56.0-build1", json={"blob": firefox_56_0_build1, "product": "Firefox", "old_data_versions": old_data_versions})
+    assert ret.status_code == 400
+
+
+@pytest.mark.usefixtures("releases_db", "mock_verified_userinfo")
+def test_put_of_only_base_blob_fails_when_signoff_required(api, firefox_56_0_build1):
+    firefox_56_0_build1 = deepcopy(firefox_56_0_build1)
+    firefox_56_0_build1["detailsUrl"] = "https://newurl"
+    old_data_versions = populate_versions_dict(firefox_56_0_build1)
+    old_data_versions["."] = 1
+
+    ret = api.put("/v2/releases/Firefox-56.0-build1", json={"blob": firefox_56_0_build1, "product": "Firefox", "old_data_versions": old_data_versions})
+    assert ret.status_code == 400
+
+
+@pytest.mark.usefixtures("releases_db", "mock_verified_userinfo")
+def test_put_of_only_modify_asset_fails_when_signoff_required(api, firefox_56_0_build1):
+    firefox_56_0_build1 = deepcopy(firefox_56_0_build1)
+    # populate this before adding new locale so it doesn't get an entry here
+    old_data_versions = populate_versions_dict(firefox_56_0_build1)
+    firefox_56_0_build1["platforms"]["Darwin_x86_64-gcc3-u-i386-x86_64"]["locales"]["de"]["buildID"] = "9999999999999"
+    old_data_versions["."] = 1
+
+    ret = api.put("/v2/releases/Firefox-56.0-build1", json={"blob": firefox_56_0_build1, "product": "Firefox", "old_data_versions": old_data_versions})
+    assert ret.status_code == 400
+
+
+@pytest.mark.usefixtures("releases_db", "mock_verified_userinfo")
+def test_put_of_new_asset_fails_when_signoff_required(api, firefox_56_0_build1):
+    firefox_56_0_build1 = deepcopy(firefox_56_0_build1)
+    # populate this before adding new locale so it doesn't get an entry here
+    old_data_versions = populate_versions_dict(firefox_56_0_build1)
+    firefox_56_0_build1["platforms"]["Darwin_x86_64-gcc3-u-i386-x86_64"]["locales"]["zz"] = copy(
+        firefox_56_0_build1["platforms"]["Darwin_x86_64-gcc3-u-i386-x86_64"]["locales"]["de"]
+    )
     old_data_versions["."] = 1
 
     ret = api.put("/v2/releases/Firefox-56.0-build1", json={"blob": firefox_56_0_build1, "product": "Firefox", "old_data_versions": old_data_versions})


### PR DESCRIPTION
We received a report that demonstrated that assets can be inserted or modified for protected releases could be inserted without signoff. It turns out that the check being fix here was broken in two ways: 1) It only required signoff if the base blob _and_ and an asset were being modified 2) It didn't compare assets correctly at all, so `current_assets != new_assets` was always true (this meant that #1 was mitigated...but only because of this bug).

This addresses both issues, and fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2047458.