### PR TITLE
Reapply "Re-enable refresh tokens in the UI (#3812)" (#3833)

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -38,6 +38,7 @@ const App = () => {
             scope: process.env.AUTH0_SCOPE,
           }}
           leeway={30}
+          useRefreshTokens
           cacheLocation="localstorage"
           sessionCheckExpiryDays={7}
         >


### PR DESCRIPTION
This reverts commit 86e65165331b191137cfbfdfdcab810930226182.

Re-enable refresh tokens now that offline access is ticked on in the auth0 config.

I was able to test this on staging, properly this time and I did see it use the refresh token to grab a new one after a weekend, making my session survive 3+ days on an env where normal tokens are bound to one day. Production should behave the same.

Also see: https://mozilla-hub.atlassian.net/browse/IAM-1994