### PR TITLE
fix: preserve `-sysaddon` in partner distribution fallback

### DIFF
--- a/src/auslib/AUS.py
+++ b/src/auslib/AUS.py
@@ -61,7 +61,10 @@ def isForbiddenUrl(url, product, allowlistedDomains):
 
 
 def getFallbackChannel(channel):
-    return channel.split("-cck-")[0]
+    fallback = channel.split("-cck-")[0]
+    if channel.endswith("-sysaddon"):
+        fallback += "-sysaddon"
+    return fallback
 
 
 class AUS:


### PR DESCRIPTION
We have a fallback so partner distribution channels map to the official channels we use in Balrog, so e.g `release-cck-ubuntu` is translated to `release`.

But if you change your update url to something like `%CHANNEL%-sysaddon` for testing purposes, the current logic continues to translate it to `release`. Instead it should be `release-sysaddon`.

This gotcha caused me some confusion while trying to validate a new system addon release on my Firefox distributed by Canonical.