### PR TITLE
docs: switch rtd config to native uv support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,12 +4,14 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.13"
-  commands:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    - uv sync --group=docs --no-dev
-    - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html
+  jobs:
+    install:
+      - uv sync --group docs --no-dev
+
+python:
+   install:
+      - method: uv
+        command: sync
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
Native uv support was added recently: https://about.readthedocs.com/blog/2026/04/uv-native-support/

And the fix for https://github.com/readthedocs/readthedocs.org/issues/13099 makes it so dev deps can be skipped.