### PR TITLE
Set cache-control for all responses from the public app

### DIFF
--- a/src/auslib/web/public/base.py
+++ b/src/auslib/web/public/base.py
@@ -42,6 +42,9 @@ def create_app():
         # See https://bugzilla.mozilla.org/show_bug.cgi?id=1332829#c4 for background.
         response.headers["Strict-Transport-Security"] = flask_app.config.get("STRICT_TRANSPORT_SECURITY", "max-age=31536000;")
         response.headers["X-Content-Type-Options"] = flask_app.config.get("CONTENT_TYPE_OPTIONS", "nosniff")
+        # setdefault so handlers that set their own Cache-Control (eg: the
+        # Dockerflow endpoints) are not overridden.
+        response.headers.setdefault("Cache-Control", flask_app.cacheControl)
         if re.match("^/ui/", request.path):
             # This enables swagger-ui to dynamically fetch and
             # load the swagger specification JSON file containing API definition and examples.

--- a/src/auslib/web/public/client.py
+++ b/src/auslib/web/public/client.py
@@ -254,7 +254,6 @@ def construct_response(release, query, update_type, response_blobs, squash_respo
 
     LOG.debug("Sending XML: %s", xml)
     response = make_response(xml)
-    response.headers["Cache-Control"] = app.cacheControl
     response.headers.extend(get_aus_metadata_headers(eval_metadata))
     if query["product"] in app.config.get("CONTENT_SIGNATURE_PRODUCTS", []):
         response.headers.extend(get_content_signature_headers(xml, query["product"]))

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -2205,9 +2205,15 @@ class ClientTestWithErrorHandlers(ClientTestCommon):
         ret = self.client.get("/update/3/c/15.0/1/p/l/a/a/default/a/update.xml")
         self.assertEqual(ret.headers.get("Cache-Control"), "public, max-age=90")
 
-    def testCacheControlIsNotSetFor404(self):
+    def testCacheControlIsSetFor404(self):
         ret = self.client.get("/whizzybang")
-        self.assertEqual(ret.headers.get("Cache-Control"), None)
+        self.assertEqual(ret.status_code, 404)
+        self.assertEqual(ret.headers.get("Cache-Control"), "public, max-age=90")
+
+    def testCacheControlIsSetForAPI(self):
+        ret = self.client.get("/api/v1/releases")
+        self.assertEqual(ret.status_code, 200)
+        self.assertEqual(ret.headers.get("Cache-Control"), "public, max-age=90")
 
     def testContentSecurityPolicyIsSet(self):
         ret = self.client.get("/update/3/c/15.0/1/p/l/a/a/default/a/update.xml")

--- a/tests/web/test_json.py
+++ b/tests/web/test_json.py
@@ -350,6 +350,13 @@ def testGuardianResponseV1WithoutSigning(client, version, buildTarget, channel, 
         assert "Content-Signature" not in ret.headers
 
 
+@pytest.mark.usefixtures("appconfig", "guardian_db")
+def testCacheControlIsSet(client):
+    ret = client.get("/json/1/Guardian/0.4.0.0/WINNT_x86_64/release/update.json")
+    assert ret.status_code == 200
+    assert ret.headers.get("Cache-Control") == "public, max-age=90"
+
+
 @pytest.mark.usefixtures("appconfig", "guardian_db", "mock_autograph")
 @pytest.mark.parametrize(
     "forceValue,response",


### PR DESCRIPTION
We were only setting it for update.xml; lift that up to the app-wide after_request callback.