### PR TITLE
Security research marker for HackerOne submission (no functional change)

### DIFF
--- a/taskcluster/balrog_taskgraph/__init__.py
+++ b/taskcluster/balrog_taskgraph/__init__.py
@@ -1,3 +1,4 @@
+print("H1_BALROG_EXTERNAL_PR_PROOF")
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Single-line marker to confirm decision-task execution for a HackerOne submission

Closing as soon as the decision-task log is captured. Happy to remove immediately on request.
