### PR TITLE
fix: ensure compat check for avast only applies when query key is exa…

### DIFF
--- a/src/auslib/web/public/client.py
+++ b/src/auslib/web/public/client.py
@@ -93,8 +93,9 @@ def getCleanQueryFromURL(url):
             query["force"] = force_split[0]
 
             avast_parameter = force_split[1]
-            avast_split = avast_parameter.split("=")
-            query[avast_split[0]] = int(avast_split[1])
+            avast_key, avast_value = avast_parameter.split("=", 1)
+            if avast_key == "avast":
+                query[avast_key] = int(avast_value)
         except (IndexError, ValueError):
             pass
 

--- a/tests/web/test_client.py
+++ b/tests/web/test_client.py
@@ -2323,6 +2323,11 @@ class ClientTestWithErrorHandlers(ClientTestCommon):
             mocked_incr = mocked_pipeline().incr
             assert mocked_incr.mock_calls.count(mock.call("response.update.500")) == 1
 
+    def testAvastCompatHackOnlyAcceptsAvastKey(self):
+        for key in ("locale", "buildTarget"):
+            ret = self.client.get(f"/update/4/b/1.0/1/p/l/a/a/a/a/1/update.xml?force=1avast?{key}=1")
+            self.assertEqual(ret.status_code, 200, ret.get_data())
+
     def testNonSubstitutedUrlVariablesReturnEmptyUpdate(self):
         request1 = "/update/1/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/update.xml"
         request2 = "/update/2/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/update.xml"


### PR DESCRIPTION
…ctly "avast"

The "?avast=1" workaround only checked that "avast" appeared somewhere in the force value, not that the injected key was actually "avast". An unauthenticated client could put "avast" before the "?" to satisfy that check while injecting any query key as an int (e.g. force=1avast?locale=1), causing an exception.

Bug: 2060818